### PR TITLE
This adds a ./login route that can take ?original_url=....

### DIFF
--- a/pulseapi/users/urls.py
+++ b/pulseapi/users/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
+    url(r'^login$', views.start_auth, name='login'),
     url(r'^logout', views.force_logout, name='logout'),
     url(r'^oauth2callback', views.callback, name='oauthcallback'),
     url(r'^nonce', views.nonce, name="get a new nonce value"),

--- a/templates/users/index.html
+++ b/templates/users/index.html
@@ -1,26 +1,5 @@
 {% if user.is_authenticated %}
     <p>Hello {{user.email}}! Would you like to <a href="logout">log out</a>?</p>
-
-    <h2>Let's try a form</h2>
-    <form method="post" action="/post">
-      {% csrf_token %}
-      <input type="hidden" name="nonce" value="{{ nonce }}">
-      <fieldset>
-        <label>
-            Name:
-            <input type="text" name="name" value="">
-        </label>
-      </fieldset>
-
-      <fieldset>
-        <label>
-            URL:
-            <input type="text" name="url" value="" placeholder="https://...">
-        </label>
-      </fieldset>
-
-      <input type="submit" value="submit">
-    </form>
 {% else %}
-    <p>Not logged in. Want to <a href="{{ auth_url }}">log in</a>?</p>
+    <p>Not logged in. Want to <a href="/login?original_url=http://test.example.com:8000">log in</a>?</p>
 {% endif %}


### PR DESCRIPTION
fixes https://github.com/mozilla/network-pulse-api/issues/24

This adds a `/login` route that clients/browsers can be redirected to, which automatically kicks off google oauth. Upon completion, the user is either redirected to `/`, or if they called `/login?original_url=.....` they will be redirected to the passed url. This allows users to log in through 3rd party web clients and be sent back to the page they were on when they went to log in.