### PR TITLE
turn off SSL functions by default

### DIFF
--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -21,7 +21,7 @@ import environ
 environ.Env.read_env(os.path.join(BASE_DIR,'.env'))
 env = environ.Env(
     DEBUG=(bool, False),
-    SSL_PROTECTION=(bool, True),
+    SSL_PROTECTION=(bool, False),
 )
 SSL_PROTECTION = env('SSL_PROTECTION')
 


### PR DESCRIPTION
This allows devs to "just work on the code" without having to worry about setting env vars to turn off https redirects, ssl protection, etc.

fixes #75