### PR TITLE
made tags, issues and creators not-required

### DIFF
--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -41,26 +41,26 @@ class Entry(models.Model):
     tags = models.ManyToManyField(
         Tag,
         related_name='entries',
-        blank=True,
+        blank=True
     )
     issues = models.ManyToManyField(
         Issue,
         related_name='entries',
-        blank=True,
+        blank=True
     )
     creators = models.ManyToManyField(
         Creator,
         related_name='entries',
-        blank=True,
+        blank=True
     )
 
     # automatically managed fields
     published_by = models.ForeignKey(
         EmailUser,
-        related_name='entries',
+        related_name='entries'
     )
     created = models.DateTimeField(
-        default = timezone.now,
+        default = timezone.now
     )
 
     objects = EntryQuerySet.as_manager()

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -51,7 +51,7 @@ class Entry(models.Model):
     creators = models.ManyToManyField(
         Creator,
         related_name='entries',
-        blank=True
+        blank=True,
     )
 
     # automatically managed fields

--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -47,15 +47,18 @@ class EntrySerializer(serializers.ModelSerializer):
 
     tags = CreatableSlugRelatedField(many=True,
                                      slug_field='name',
-                                     queryset=Tag.objects)
+                                     queryset=Tag.objects,
+                                     required=False,)
 
     issues = serializers.SlugRelatedField(many=True,
                                           slug_field='name',
-                                          queryset=Issue.objects)
+                                          queryset=Issue.objects,
+                                          required=False,)
 
     creators = CreatableSlugRelatedField(many=True,
                                          slug_field='name',
-                                         queryset=Creator.objects)
+                                         queryset=Creator.objects,
+                                         required=False,)
 
     bookmark_count = serializers.SerializerMethodField()
 
@@ -81,10 +84,6 @@ class EntrySerializer(serializers.ModelSerializer):
                 return res.count() > 0
 
         return False
-
-    creators = CreatableSlugRelatedField(many=True,
-                                         slug_field='name',
-                                         queryset=Creator.objects)
 
     class Meta:
         """

--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -48,17 +48,17 @@ class EntrySerializer(serializers.ModelSerializer):
     tags = CreatableSlugRelatedField(many=True,
                                      slug_field='name',
                                      queryset=Tag.objects,
-                                     required=False,)
+                                     required=False)
 
     issues = serializers.SlugRelatedField(many=True,
                                           slug_field='name',
                                           queryset=Issue.objects,
-                                          required=False,)
+                                          required=False)
 
     creators = CreatableSlugRelatedField(many=True,
                                          slug_field='name',
                                          queryset=Creator.objects,
-                                         required=False,)
+                                         required=False)
 
     bookmark_count = serializers.SerializerMethodField()
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/network-pulse-api/issues/80 by marking the tags, issues and creators as `require=False` in the serializer for Entries