### PR TITLE
fix migration so it can deal with "duplicates"

### DIFF
--- a/pulseapi/entries/migrations/0010_migrate_approval_flags.py
+++ b/pulseapi/entries/migrations/0010_migrate_approval_flags.py
@@ -15,8 +15,9 @@ def forwards_func(apps, schema_editor):
                 title=entry.title,
                 content_url=entry.content_url
             )
-            migrated_entry.moderation_state = approved
-            migrated_entry.save()
+            for m_entry in migrated_entry:
+                m_entry.moderation_state = approved
+                m_entry.save()
 
 
 class Migration(migrations.Migration):

--- a/pulseapi/entries/migrations/0010_migrate_approval_flags.py
+++ b/pulseapi/entries/migrations/0010_migrate_approval_flags.py
@@ -11,7 +11,7 @@ def forwards_func(apps, schema_editor):
     entries = apps.get_model('entries', 'Entry').objects.all()
     for entry in entries:
         if entry.is_approved:
-            migrated_entry = Entry.objects.get(
+            migrated_entry = Entry.objects.filter(
                 title=entry.title,
                 content_url=entry.content_url
             )


### PR DESCRIPTION
This fixes #122 so that if it finds multiple entries with the same `{title, content_url}` tuple, it won't crash the manage.py process.

Test instructions: see https://github.com/mozilla/network-pulse-api/pull/123#issuecomment-306330071