### PR TITLE
add moderator status to userstatus readout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The call response is a JSON object of the following form:
   username: <string: the user's full name according to Google>,
   email: <string: the user's google-login-associated email address>
   loggedin: <boolean: whether this user is logged in or not>
+  moderator: <boolean: whether this logged-in user has moderation rights>
 }
 ```
 

--- a/pulseapi/users/admin_group_editing.py
+++ b/pulseapi/users/admin_group_editing.py
@@ -1,4 +1,10 @@
-# https://stackoverflow.com/questions/39485067/django-add-user-to-group-via-django-admin
+# ==========================================================
+#
+#  Custom code to add user management in group admin views.
+#
+#  See  https://stackoverflow.com/questions/39485067
+#
+# ==========================================================
 
 from django import forms
 from django.contrib import admin
@@ -39,8 +45,6 @@ class GroupAdminForm(forms.ModelForm):
         instance.save()
         return instance
 
-# Unregister the original Group admin.
-admin.site.unregister(Group)
 
 # Create a new Group admin.
 class GroupAdmin(admin.ModelAdmin):
@@ -49,5 +53,3 @@ class GroupAdmin(admin.ModelAdmin):
     # Filter permissions horizontal as well.
     filter_horizontal = ['permissions']
 
-# Register the new Group ModelAdmin.
-admin.site.register(Group, GroupAdmin)

--- a/pulseapi/users/views.py
+++ b/pulseapi/users/views.py
@@ -88,16 +88,26 @@ def userstatus(request):
     """
     name = False
     email = False
-    loggedin = request.user.is_authenticated()
+    user = request.user
+    loggedin = user.is_authenticated()
+
+    # A user is a moderator if they are in the moderator group
+    # or if they are a superuser, because superusers can do anything.
+    moderator = user.groups.filter(name='moderator')
+    is_moderator = len(moderator) > 0
+
+    if is_moderator is False
+        is_moderator = user.is_superuser
 
     if loggedin:
-        name = request.user.name
-        email = request.user.email
+        name = user.name
+        email = user.email
 
     return render(request, 'users/userstatus.json', {
         'username': name,
         'email': email,
-        'loggedin': loggedin
+        'loggedin': loggedin,
+        'moderator': is_moderator,
     }, content_type="application/json")
 
 

--- a/templates/users/userstatus.json
+++ b/templates/users/userstatus.json
@@ -1,5 +1,7 @@
 {
 {% if loggedin %}	"username": "{{ username }}",
 {% endif %}{% if loggedin %}	"email": "{{ email }}",
-{% endif %}	"loggedin": {% if loggedin %}true{% else %}false{% endif %}
+{% endif %}	"loggedin": {% if loggedin %}true{% else %}false
+{% endif %}{% if moderator %},
+	"moderator": true{% endif %}
 }


### PR DESCRIPTION
this adds a "moderator" field to the `userstatus` response, so that clients can tell whether a logged in user has moderation rights or not.

Response will containt `moderator: true` if the user is in the "moderators" group, or if they're a superuser