### PR TITLE
entries: Make `get_involved` and `interest` fields searchable

### DIFF
--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -217,7 +217,8 @@ class EntriesListView(ListCreateAPIView):
 
     #Query Parameters -
 
-    - `?search=` - Search by title, description, creator, and tag.
+    - `?search=` - Search by title, description, get_involved, interest,
+                   creator, and tag.
     - `?ids=` - Filter only for entries with specific ids. Argument
                 must be a comma-separated list of integer ids.
     - `?tag=` - Allows filtering entries by a specific tag

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -241,6 +241,8 @@ class EntriesListView(ListCreateAPIView):
     search_fields = (
         'title',
         'description',
+        'get_involved',
+        'interest',
         'tags__name',
         'creators__name',
     )


### PR DESCRIPTION
Fixes https://github.com/mozilla/network-pulse/issues/594