### PR TITLE
Add a profile view/update route

### DIFF
--- a/pulseapi/helptypes/tests.py
+++ b/pulseapi/helptypes/tests.py
@@ -6,7 +6,7 @@ from .models import HelpType
 class TestIssues(TestCase):
 
     def test_check_for_help_types(self):
-        help_types = self.client.get('/helptypes/')
+        help_types = self.client.get('/api/pulse/helptypes/')
         help_type_json = json.loads(str(help_types.content, 'utf-8'))
         self.assertEqual(help_types.status_code, 200)
         self.assertEqual(len(help_type_json), 13)

--- a/pulseapi/profiles/models.py
+++ b/pulseapi/profiles/models.py
@@ -188,6 +188,9 @@ class UserProfile(models.Model):
     )
 
     def __str__(self):
+        if self.user is None:
+            return 'orphan profile'
+
         return 'profile for {}'.format(self.user.email)
 
     class Meta:

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -56,4 +56,3 @@ class UserProfileSerializer(serializers.ModelSerializer):
             'bookmarks',
             'id',
         ]
-

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -39,11 +39,22 @@ class UserProfileSerializer(serializers.ModelSerializer):
         queryset=Issue.objects,
         required=True
     )
-
-    twitter = serializers.URLField(max_length=2048)
-    linkedin = serializers.URLField(max_length=2048)
-    github = serializers.URLField(max_length=2048)
-    website = serializers.URLField(max_length=2048)
+    twitter = serializers.URLField(
+        max_length=2048,
+        required=False
+    )
+    linkedin = serializers.URLField(
+        max_length=2048,
+        required=False
+    )
+    github = serializers.URLField(
+        max_length=2048,
+        required=False
+    )
+    website = serializers.URLField(
+        max_length=2048,
+        required=False
+    )
 
     class Meta:
         """

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -40,10 +40,10 @@ class UserProfileSerializer(serializers.ModelSerializer):
         required=True
     )
 
-    twitter = serializers.models.URLField(max_length=2048)
-    linkedin = serializers.models.URLField(max_length=2048)
-    github = serializers.models.URLField(max_length=2048)
-    website = serializers.models.URLField(max_length=2048)
+    twitter = serializers.URLField(max_length=2048)
+    linkedin = serializers.URLField(max_length=2048)
+    github = serializers.URLField(max_length=2048)
+    website = serializers.URLField(max_length=2048)
 
     class Meta:
         """

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
-from pulseapi.users.models import UserBookmarks
+
+from pulseapi.issues.models import Issue
+from pulseapi.profiles.models import UserProfile, UserBookmarks
 
 
 class UserBookmarksSerializer(serializers.ModelSerializer):
@@ -12,3 +14,46 @@ class UserBookmarksSerializer(serializers.ModelSerializer):
         Meta class. Again: because
         """
         model = UserBookmarks
+
+
+class UserProfileSerializer(serializers.ModelSerializer):
+    """
+    Serializes a user profile.
+    """
+    user_bio = serializers.CharField(
+        max_length=140,
+        required=False
+    )
+    custom_name = serializers.CharField(
+        max_length=500,
+        required=False
+    )
+    is_group = serializers.BooleanField()
+    thumbnail = serializers.ImageField(
+        max_length=2048,
+        required=False
+    )
+    issues = serializers.SlugRelatedField(
+        many=True,
+        slug_field='name',
+        queryset=Issue.objects,
+        required=True
+    )
+
+    twitter = serializers.models.URLField(max_length=2048)
+    linkedin = serializers.models.URLField(max_length=2048)
+    github = serializers.models.URLField(max_length=2048)
+    website = serializers.models.URLField(max_length=2048)
+
+    class Meta:
+        """
+        Meta class. Because
+        """
+        model = UserProfile
+        exclude = [
+            'is_active',
+            'user',
+            'bookmarks',
+            'id',
+        ]
+

--- a/pulseapi/profiles/urls.py
+++ b/pulseapi/profiles/urls.py
@@ -1,4 +1,13 @@
-# from django.conf.urls import url
-# from . import views
+from django.conf.urls import url
 
-urlpatterns = []
+from pulseapi.profiles.views import (
+    ProfileView,
+)
+
+urlpatterns = [
+    url(
+        r'^(?P<pk>[0-9]+)/',
+        ProfileView.as_view(),
+        name='profile'
+    )
+]

--- a/pulseapi/profiles/urls.py
+++ b/pulseapi/profiles/urls.py
@@ -1,13 +1,13 @@
 from django.conf.urls import url
 
 from pulseapi.profiles.views import (
-    ProfileView,
+    UserProfileChangeAPIView,
 )
 
 urlpatterns = [
     url(
-        r'^(?P<pk>[0-9]+)/',
-        ProfileView.as_view(),
+        r'^myprofile/',
+        UserProfileChangeAPIView.as_view(),
         name='profile'
     )
 ]

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -21,5 +21,5 @@ class UserProfileChangeAPIView(RetrieveUpdateAPIView):
     serializer_class = UserProfileSerializer
 
     def get_object(self):
-        user = self.request.user;
+        user = self.request.user
         return get_object_or_404(UserProfile, user=user)

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -1,1 +1,36 @@
-# from django.conf import settings
+from rest_framework.generics import RetrieveAPIView
+from rest_framework.decorators import detail_route, api_view
+from rest_framework.response import Response
+from rest_framework import filters, status
+
+from pulseapi.profiles.models import UserProfile
+from pulseapi.profiles.serializers import UserProfileSerializer
+
+
+class ProfileView(RetrieveAPIView):
+    """
+    A view to retrieve individual profiles
+    """
+
+    def get_queryset(self):
+        return UserProfile.objects.all()
+
+    serializer_class = UserProfileSerializer
+    pagination_class = None
+
+	# When people POST to this route, we want to
+	# update the profile with the new information.
+    @detail_route(methods=['post'])
+    def post(self, request, *args, **kwargs):
+        profile = UserProfile.objects.get(id=self.kwargs['pk']);
+        serializer = UserProfileSerializer(profile, data=request.data)
+
+        if serializer.is_valid():
+            profile = serializer.save()
+            return Response({'status': 'updated', 'id': profile.id})
+
+        else:
+            return Response(
+                serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST
+            )

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -25,18 +25,11 @@ urlpatterns = [
     # new patterns
     url(r'^api/pulse/', include('pulseapi.users.urls')),
     url(r'^api/pulse/entries/', include('pulseapi.entries.urls')),
+    url(r'^api/pulse/profiles/', include('pulseapi.profiles.urls')),
     url(r'^api/pulse/tags/', include('pulseapi.tags.urls')),
     url(r'^api/pulse/issues/', include('pulseapi.issues.urls')),
     url(r'^api/pulse/helptypes/', include('pulseapi.helptypes.urls')),
     url(r'^api/pulse/creators/', include('pulseapi.creators.urls')),
-
-    # deprecated patterns
-    url(r'^', include('pulseapi.users.urls')),
-    url(r'^entries/', include('pulseapi.entries.urls')),
-    url(r'^tags/', include('pulseapi.tags.urls')),
-    url(r'^issues/', include('pulseapi.issues.urls')),
-    url(r'^helptypes/', include('pulseapi.helptypes.urls')),
-    url(r'^creators/', include('pulseapi.creators.urls')),
 ]
 
 if settings.USE_S3 is not True:

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
 
     # 'homepage'
-    url(r'^$', include('pulseapi.users.urls')),
+    url(r'^', include('pulseapi.users.urls')),
 
     # API routes
     url(r'^api/pulse/', include('pulseapi.users.urls')),

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -19,10 +19,13 @@ from django.contrib import admin
 from django.conf.urls.static import static
 
 urlpatterns = [
-    # base patterns
+    # admin patterns
     url(r'^admin/', admin.site.urls),
 
-    # new patterns
+    # 'homepage'
+    url(r'^$', include('pulseapi.users.urls')),
+
+    # API routes
     url(r'^api/pulse/', include('pulseapi.users.urls')),
     url(r'^api/pulse/entries/', include('pulseapi.entries.urls')),
     url(r'^api/pulse/profiles/', include('pulseapi.profiles.urls')),


### PR DESCRIPTION
ideally we have an `/api/pulse/myprofile` route that pulls up the profile of an authenticated user. However, I'm having a surprisingly hard time making that happen right now. 

@gideonthomas want to help with this?

closes https://github.com/mozilla/network-pulse-api/issues/170