### PR TITLE
Order creators in entries by post date

### DIFF
--- a/pulseapi/creators/serializers.py
+++ b/pulseapi/creators/serializers.py
@@ -19,9 +19,10 @@ class CreatorSerializer(serializers.ModelSerializer):
 
 
 class OrderedCreatorRecordSerializer(serializers.ModelSerializer):
+    creator = CreatorSerializer()
 
     class Meta:
         model = OrderedCreatorRecord
         fields = (
-            'pk',
+            'creator',
         )

--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -6,7 +6,7 @@ from pulseapi.entries.models import Entry, ModerationState
 from pulseapi.tags.models import Tag
 from pulseapi.issues.models import Issue
 from pulseapi.helptypes.models import HelpType
-from pulseapi.creators.models import Creator, OrderedCreatorRecord
+from pulseapi.creators.models import OrderedCreatorRecord
 from pulseapi.creators.serializers import OrderedCreatorRecordSerializer
 from pulseapi.profiles.models import UserProfile
 
@@ -69,10 +69,20 @@ class EntrySerializer(serializers.ModelSerializer):
         required=False
     )
 
-    creators = OrderedCreatorRecordSerializer(
-        many=True,
-        required=False
-    )
+    creators = serializers.SerializerMethodField()
+
+    def get_creators(self, instance):
+        """
+        Get the list of creators for this entry ordered by
+        when they posted the entry
+        """
+        serializer = OrderedCreatorRecordSerializer(
+            data=OrderedCreatorRecord.objects.filter(entry=instance),
+            many=True,
+        )
+
+        serializer.is_valid()
+        return serializer.data
 
     # overrides 'published_by' for REST purposes
     # as we don't want to expose any user's email address


### PR DESCRIPTION
This should force it to be ordered by the order in which the creator-entry relations are added in the through model (since you specify ordering in the model itself) instead of the order in the creator model. From what I read, the ordering of through models is only respected on querysets that are queried on that model and not the creator model. So this patch queries the OrderedCreatorRecord model instead of the Creator model and so the ordering follows whatever you specified on that model.

I also changed the serializer to serialize the relation as a creator (the same way the CreatorSerializer works). Feel free to revert that if not needed.