### PR TITLE
expose submitter_profile_id for entries

### DIFF
--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -90,13 +90,17 @@ class EntrySerializer(serializers.ModelSerializer):
         return instance.published_by.name
 
     # "virtual" property so that we can link to the correct profile
-    submitter_id = serializers.SerializerMethodField()
+    submitter_profile_id = serializers.SerializerMethodField()
 
-    def get_submitter_id(self, instance):
+    def get_submitter_profile_id(self, instance):
         """
         Get the id for the user who published this entry
         """
-        return instance.published_by.id
+        profiles = instance.published_by.profile.all()
+        if len(profiles) > 0:
+            profile = profiles[0]
+            return profile.id
+        return False
 
     bookmark_count = serializers.SerializerMethodField()
 

--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -89,6 +89,15 @@ class EntrySerializer(serializers.ModelSerializer):
         """
         return instance.published_by.name
 
+    # "virtual" property so that we can link to the correct profile
+    submitter_id = serializers.SerializerMethodField()
+
+    def get_submitter_id(self, instance):
+        """
+        Get the id for the user who published this entry
+        """
+        return instance.published_by.id
+
     bookmark_count = serializers.SerializerMethodField()
 
     def get_bookmark_count(self, instance):
@@ -120,4 +129,6 @@ class EntrySerializer(serializers.ModelSerializer):
         Meta class. Because
         """
         model = Entry
-        exclude = ('internal_notes', 'published_by',)
+        exclude = (
+            'internal_notes',
+        )


### PR DESCRIPTION
This adds a `submitter_profile_id` property to entries, which can be used to crosslink entries to the posting user's profile in the client