### PR TITLE
Allow fields in myprofile payload to be blank

### DIFF
--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -26,11 +26,13 @@ class UserProfileSerializer(serializers.ModelSerializer):
     """
     user_bio = serializers.CharField(
         max_length=140,
-        required=False
+        required=False,
+        allow_blank=True,
     )
     custom_name = serializers.CharField(
         max_length=70,
-        required=False
+        required=False,
+        allow_blank=True,
     )
     is_group = serializers.BooleanField()
     issues = serializers.SlugRelatedField(
@@ -41,19 +43,23 @@ class UserProfileSerializer(serializers.ModelSerializer):
     )
     twitter = serializers.URLField(
         max_length=2048,
-        required=False
+        required=False,
+        allow_blank=True,
     )
     linkedin = serializers.URLField(
         max_length=2048,
-        required=False
+        required=False,
+        allow_blank=True,
     )
     github = serializers.URLField(
         max_length=2048,
-        required=False
+        required=False,
+        allow_blank=True,
     )
     website = serializers.URLField(
         max_length=2048,
-        required=False
+        required=False,
+        allow_blank=True,
     )
 
     class Meta:

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -34,7 +34,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
         required=False,
         allow_blank=True,
     )
-    is_group = serializers.BooleanField()
+    is_group = serializers.BooleanField(read_only=True)
     issues = serializers.SlugRelatedField(
         many=True,
         slug_field='name',


### PR DESCRIPTION
Fixes #206 

You can now pass empty strings to these fields and they will be considered valid values. Tbh, there's probably a better way to do this with `null` since django treats `null` and `""` as two distinct values for strings while on the front-end we treat them as the same. But I think this works fine for now.