### PR TITLE
Send profile info for creators when fetching entries

### DIFF
--- a/pulseapi/creators/serializers.py
+++ b/pulseapi/creators/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from pulseapi.creators.models import Creator
+from pulseapi.creators.models import Creator, OrderedCreatorRecord
 
 
 class CreatorSerializer(serializers.ModelSerializer):
@@ -16,3 +16,29 @@ class CreatorSerializer(serializers.ModelSerializer):
         """
         model = Creator
         fields = ('name', )
+
+
+class EntryOrderedCreatorSerializer(serializers.ModelSerializer):
+    """
+    Serializes creators to be shown in entries where each creator has
+    a profile_id if the creator has a user attached to it
+    """
+    profile_id = serializers.SerializerMethodField()
+
+    def get_profile_id(self, instance):
+        user = instance.creator.user
+
+        return user.get_self_profile().id if user else None
+
+    # The name of the creator. If the creator is a user, the user's name is
+    # used instead
+    name = serializers.SerializerMethodField()
+
+    def get_name(self, instance):
+        user = instance.creator.user
+
+        return user.get_self_profile().name() if user else instance.creator.name
+
+    class Meta:
+        model = OrderedCreatorRecord
+        fields = ('profile_id', 'name',)

--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -82,7 +82,7 @@ class EntrySerializer(serializers.ModelSerializer):
 
     # Although this field has similar results to the field above (it's just
     # serialized differently), we create a new field vs. overriding the field
-    # above so that we maintain backwards compatibility
+    # above so that we maintain backward compatibility
     creators_with_profiles = serializers.SerializerMethodField()
 
     def get_creators_with_profiles(self, instance):

--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -7,6 +7,7 @@ from pulseapi.tags.models import Tag
 from pulseapi.issues.models import Issue
 from pulseapi.helptypes.models import HelpType
 from pulseapi.profiles.models import UserProfile
+from pulseapi.creators.serializers import EntryOrderedCreatorSerializer
 
 
 class CreatableSlugRelatedField(serializers.SlugRelatedField):
@@ -78,6 +79,27 @@ class EntrySerializer(serializers.ModelSerializer):
         (see creators.models.OrderedCreatorRecord Meta class)
         """
         return [ocr.creator.name for ocr in instance.related_creators.all()]
+
+    # Although this field has similar results to the field above (it's just
+    # serialized differently), we create a new field vs. overriding the field
+    # above so that we maintain backwards compatibility
+    creators_with_profiles = serializers.SerializerMethodField()
+
+    def get_creators_with_profiles(self, instance):
+        """
+        Get the list of ordered creators with their associated profile info,
+        if any, for this entry. Each creator is serialized as:
+        {
+            "profile_id": <the profile id associated with the creator or null
+            if there isn't a profile associated with it>,
+            "name": <the name of the creator; uses the profile's name if there
+            is a profile>
+        }
+        """
+        return EntryOrderedCreatorSerializer(
+            instance.related_creators.all(),
+            many=True,
+        ).data
 
     # overrides 'published_by' for REST purposes
     # as we don't want to expose any user's email address

--- a/pulseapi/users/models.py
+++ b/pulseapi/users/models.py
@@ -77,6 +77,14 @@ class EmailUser(AbstractBaseUser, PermissionsMixin):
     def clean(self):
         pass
 
+    def get_self_profile(self):
+        """
+        Returns the profile belonging to this user object since
+        a user can have multiple profiles attached to it that
+        represent organizations
+        """
+        return self.profile.filter(is_group=False).last()
+
     def toString(self):
         return self.email
 


### PR DESCRIPTION
Addresses part of mozilla/network-pulse#624

This is most of the work we need to do for the front-end to distinguish between creators with profiles and creators without profiles.

Things that still need to be done:
- Fixing how we get a users own profile, since they can own multiple profiles. It's kinda hacky to rely on `is_group` since that would mean that admins who manage profiles have to manually make sure that for a user that has multiple profiles, only one of those profiles has `is_group` set to `False` viz. their own profile
- Exposing a list of creators so that the front-end can use it for auto-complete
   - Part of this is also fixing how creators are created when posting a new entry - not just doing it based on name but also based on profile (automatically linking a profile to a creator)

Will file issues for the above!