### PR TITLE
Update CORS default domains

### DIFF
--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -173,7 +173,7 @@ CORS_ALLOW_CREDENTIALS = True
 # and we want origin whitelisting
 CORS_ORIGIN_WHITELIST = os.getenv(
     'CORS_ORIGIN_WHITELIST',
-    'localhost:3000,localhost:8000,localhost:8080,test.example.com:8000,test.example.com:8080'
+    'localhost:3000,localhost:8000,localhost:8080,test.example.com:8000,test.example.com:3000'
 ).split(',')
 
 CORS_ORIGIN_REGEX_WHITELIST = []


### PR DESCRIPTION
Pulse front-end uses port `3000` instead of `8080`