### PR TITLE
Test creators being serialized correctly for entries

### DIFF
--- a/pulseapi/creators/test_models.py
+++ b/pulseapi/creators/test_models.py
@@ -1,0 +1,14 @@
+import factory
+from faker import Factory as FakerFactory
+from pulseapi.creators.models import Creator
+
+
+faker = FakerFactory.create()
+
+
+class CreatorFactory(factory.DjangoModelFactory):
+
+    name = factory.LazyAttribute(lambda o: faker.name())
+
+    class Meta:
+        model = Creator

--- a/pulseapi/creators/tests.py
+++ b/pulseapi/creators/tests.py
@@ -10,17 +10,6 @@ class TestCreators(PulseStaffTestCase):
 
     def test_creator_filtering(self):
         """search creators, for autocomplete"""
-        payload = {
-            'title': 'title test_creator_filtering',
-            'content_url': 'http://example.com/test_creator_filtering',
-            'description': 'description test_creator_filtering',
-            'creators': ['Alice', 'Bob', 'Carol']
-        }
-        json.loads(str(self.client.get('/api/pulse/nonce/').content, 'utf-8'))
-        self.client.post(
-            '/api/pulse/entries/',
-            data=self.generatePostPayload(data=payload)
-        )
         creatorList = json.loads(
             str(self.client.get(
                 '/api/pulse/creators/?search=A'
@@ -30,6 +19,5 @@ class TestCreators(PulseStaffTestCase):
         for creator in self.creators:
             if creator.name.startswith('A'):
                 db_creators.append(creator.name)
-        db_creators.append('Alice')
 
         self.assertEqual(creatorList, db_creators)

--- a/pulseapi/creators/tests.py
+++ b/pulseapi/creators/tests.py
@@ -26,4 +26,10 @@ class TestCreators(PulseStaffTestCase):
                 '/api/pulse/creators/?search=A'
             ).content, 'utf-8')
         )
-        self.assertEqual(creatorList, ['Alice'])
+        db_creators = []
+        for creator in self.creators:
+            if creator.name.startswith('A'):
+                db_creators.append(creator.name)
+        db_creators.append('Alice')
+
+        self.assertEqual(creatorList, db_creators)

--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -139,7 +139,9 @@ class EntrySerializer(serializers.ModelSerializer):
         Check whether the current user has bookmarked this
         Entry. Anonymous users always see False
         """
-        request = self.context['request']
+        request = None
+        if hasattr(self.context, 'request') and self.context['request']:
+            request = self.context['request']
 
         if hasattr(request, 'user'):
             user = request.user

--- a/pulseapi/entries/test_views.py
+++ b/pulseapi/entries/test_views.py
@@ -2,7 +2,7 @@ import json
 
 from django.core.urlresolvers import reverse
 
-from pulseapi.creators.models import OrderedCreatorRecord
+from pulseapi.creators.models import Creator, OrderedCreatorRecord
 from pulseapi.entries.models import Entry, ModerationState
 from pulseapi.entries.serializers import EntrySerializer
 from pulseapi.tests import PulseStaffTestCase, PulseMemberTestCase
@@ -192,8 +192,7 @@ class TestEntryView(PulseStaffTestCase):
         creator_list = json.loads(
             str(self.client.get('/api/pulse/creators/').content, 'utf-8')
         )
-        db_creator_list = [c.name for c in self.creators]
-        db_creator_list.extend(creators)
+        db_creator_list = list(Creator.objects.values_list('name', flat=True))
         self.assertEqual(db_creator_list, creator_list)
 
     def test_get_entries_list(self):

--- a/pulseapi/entries/test_views.py
+++ b/pulseapi/entries/test_views.py
@@ -2,7 +2,9 @@ import json
 
 from django.core.urlresolvers import reverse
 
+from pulseapi.creators.models import OrderedCreatorRecord
 from pulseapi.entries.models import Entry, ModerationState
+from pulseapi.entries.serializers import EntrySerializer
 from pulseapi.tests import PulseStaffTestCase, PulseMemberTestCase
 
 
@@ -174,10 +176,11 @@ class TestEntryView(PulseStaffTestCase):
         See if creators endpoint has proper results afterwards
         """
 
+        creators = ['Pomax', 'Alan']
         payload = {
             'title': 'title test_post_entry_with_mixed_tags2',
             'description': 'description test_post_entry_with_mixed_tags',
-            'creators': ['Pomax', 'Alan'],
+            'creators': creators,
         }
         json.loads(
             str(self.client.get('/api/pulse/nonce/').content, 'utf-8')
@@ -186,10 +189,12 @@ class TestEntryView(PulseStaffTestCase):
             '/api/pulse/entries/',
             data=self.generatePostPayload(data=payload)
         )
-        creatorList = json.loads(
+        creator_list = json.loads(
             str(self.client.get('/api/pulse/creators/').content, 'utf-8')
         )
-        self.assertEqual(creatorList, ['Pomax', 'Alan'])
+        db_creator_list = [c.name for c in self.creators]
+        db_creator_list.extend(creators)
+        self.assertEqual(db_creator_list, creator_list)
 
     def test_get_entries_list(self):
         """Get /entries endpoint"""
@@ -553,6 +558,29 @@ class TestEntryView(PulseStaffTestCase):
         # and did it change the moderation state?
         entry = Entry.objects.get(id=entry_id)
         self.assertEqual(entry.moderation_state, state)
+
+    def test_entry_serializer(self):
+        """
+        Make sure that the entry serializer contains all the custom data needed.
+        Useful test to make sure our custom fields are tested and not
+        removed during API changes
+        """
+
+        entries = self.entries
+        serialized_entries = EntrySerializer(entries, many=True).data
+
+        for i in range(len(serialized_entries)):
+            entry = entries[i]
+            serialized_entry = dict(serialized_entries[i])
+            # Make sure that the property exists in the serialized entry
+            self.assertIn('creators_with_profiles', serialized_entry)
+            creators_with_profiles = serialized_entry['creators_with_profiles']
+            # Make sure that the number of serialized creators matches the
+            # number of creators for that entry in the db
+            self.assertEqual(
+                len(creators_with_profiles),
+                OrderedCreatorRecord.objects.filter(entry=entry).count()
+            )
 
 
 class TestMemberEntryView(PulseMemberTestCase):

--- a/pulseapi/profiles/test_models.py
+++ b/pulseapi/profiles/test_models.py
@@ -11,7 +11,9 @@ class UserProfileFactory(factory.Factory):
     """Generate UserProfiles for tests"""
     is_active = True
     user_bio = factory.LazyAttribute(
-        lambda o: 'user_bio {}'.format(''.join(fake.text(max_nb_chars=130)))
+        lambda o: 'user_bio {fake_bio}'.format(
+            fake_bio=''.join(fake.text(max_nb_chars=130))
+        )
     )
 
     class Meta:

--- a/pulseapi/profiles/test_models.py
+++ b/pulseapi/profiles/test_models.py
@@ -1,0 +1,19 @@
+"""UserProfile Model Generator"""
+from pulseapi.profiles.models import UserProfile
+
+import factory
+from faker import Factory
+
+fake = Factory.create()
+
+
+class UserProfileFactory(factory.Factory):
+    """Generate UserProfiles for tests"""
+    is_active = True
+    user_bio = factory.LazyAttribute(
+        lambda o: 'user_bio {}'.format(''.join(fake.text(max_nb_chars=130)))
+    )
+
+    class Meta:
+        """Tell factory that it should be generating UserProfiles"""
+        model = UserProfile


### PR DESCRIPTION
This is the last bit for https://github.com/mozilla/network-pulse/issues/624.

We only need to test the serializer (vs. the whole route since other tests already test this) since that is where we have our custom logic.

I had to actually create creators and link them to entries in the setup (which broke a few tests re: creators, so I fixed them). 