### PR TITLE
Profile thumbnails should be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Allows an authenticated user to update their profile data. The payload that need
   thumbnail: optional object {
     name: name of the file,
     base64: the base64 encoded binary representation of the file's bytes
-  }
+  }, if you pass in null, the thumbnail will be set to null
   twitter: optional url link to twitter account
   linkedin: optional url link to linkedin account
   github: optional url link to github account

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -35,6 +35,10 @@ class UserProfileSerializer(serializers.ModelSerializer):
         allow_blank=True,
     )
     is_group = serializers.BooleanField(read_only=True)
+    thumbnail = serializers.ImageField(
+        required=False,
+        allow_null=True,
+    )
     issues = serializers.SlugRelatedField(
         many=True,
         slug_field='name',


### PR DESCRIPTION
It should now be optional. But it treat `null` as a special case. If you send `null`, it will literally set the thumbnail to `null`. If you don't want to change the value of thumbnail and leave it as it is, just don't send the key.

@mmmavis let me know if this is meant to be the expected behavior or not.