### PR TITLE
Ensure that tags with commas get separated into real tags

### DIFF
--- a/pulseapi/entries/test_views.py
+++ b/pulseapi/entries/test_views.py
@@ -168,6 +168,27 @@ class TestEntryView(PulseStaffTestCase):
         )
         self.assertEqual(tagList, ['test1', 'test2', 'test3'])
 
+    def test_post_entry_with_comma_infused_tags(self):
+        """
+        Post entries with some existing tags, some new tags
+        See if tags endpoint has proper results afterwards
+        """
+
+        content_url = 'http://example.com/test_post_entry_with_comma_infused_tags'
+        payload = {
+            'title': 'title test_post_entry_with_comma_infused_tags',
+            'content_url': content_url,
+            'tags': ['test1', 'test2', 'test1,test2,test3'],
+        }
+        self.client.post(
+            '/api/pulse/entries/',
+            data=self.generatePostPayload(data=payload)
+        )
+        tagList = json.loads(
+            str(self.client.get('/api/pulse/tags/').content, 'utf-8')
+        )
+        self.assertEqual(tagList, ['test1', 'test2', 'test3'])
+
     def test_post_entry_with_mixed_creators(self):
         """
         Post entry with some existing creators, some new creators

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -428,17 +428,19 @@ class EntriesListView(ListCreateAPIView):
 
             # we also want to make sure that tags are properly split
             # on commas, in case we get e.g. ['a', 'b' 'c,d']
-            print(request_data)
-            tags = request_data['tags'] if 'tags' in request_data else []
-            print(tags)
-            filtered_tags = []
-            for tag in tags:
-                if ',' in tag:
-                    filtered_tags = filtered_tags + tag.split(',')
-                else:
-                    filtered_tags.append(tag)
-            print(filtered_tags)
-            request_data['tags'] = list(set(filtered_tags))
+            if 'tags' in request_data:
+                print(request_data['tags'])
+                tags = request.POST.getlist('tags')
+                print('tags', tags)
+                filtered_tags = []
+                for tag in tags:
+                    print('tag', tag)
+                    if ',' in tag:
+                        filtered_tags = filtered_tags + tag.split(',')
+                    else:
+                        filtered_tags.append(tag)
+                print('filtered', filtered_tags)
+                request_data['tags'] = str(set(filtered_tags))
 
             serializer = EntrySerializer(data=request_data)
             if serializer.is_valid():

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -426,6 +426,20 @@ class EntriesListView(ListCreateAPIView):
             # relation with a Through class, so that needs manual labour:
             creator_data = request_data.pop('creators', None)
 
+            # we also want to make sure that tags are properly split
+            # on commas, in case we get e.g. ['a', 'b' 'c,d']
+            print(request_data)
+            tags = request_data['tags'] if 'tags' in request_data else []
+            print(tags)
+            filtered_tags = []
+            for tag in tags:
+                if ',' in tag:
+                    filtered_tags = filtered_tags + tag.split(',')
+                else:
+                    filtered_tags.append(tag)
+            print(filtered_tags)
+            request_data['tags'] = list(set(filtered_tags))
+
             serializer = EntrySerializer(data=request_data)
             if serializer.is_valid():
                 user = request.user

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -429,18 +429,14 @@ class EntriesListView(ListCreateAPIView):
             # we also want to make sure that tags are properly split
             # on commas, in case we get e.g. ['a', 'b' 'c,d']
             if 'tags' in request_data:
-                print(request_data['tags'])
                 tags = request.POST.getlist('tags')
-                print('tags', tags)
                 filtered_tags = []
                 for tag in tags:
-                    print('tag', tag)
                     if ',' in tag:
                         filtered_tags = filtered_tags + tag.split(',')
                     else:
                         filtered_tags.append(tag)
-                print('filtered', filtered_tags)
-                request_data['tags'] = str(set(filtered_tags))
+                request_data.setlist('tags', list(set(filtered_tags)))
 
             serializer = EntrySerializer(data=request_data)
             if serializer.is_valid():

--- a/pulseapi/tags/models.py
+++ b/pulseapi/tags/models.py
@@ -40,7 +40,7 @@ class Tag(models.Model):
             terms = name.split(',')
             self.name = terms[0]
             for term in terms[1:]:
-                Tag.objects.create(name=term)
+                Tag.objects.get_or_create(name=term)
 
         self.full_clean()
         super(Tag, self).save(*args, **kwargs)

--- a/pulseapi/tags/models.py
+++ b/pulseapi/tags/models.py
@@ -31,6 +31,17 @@ class Tag(models.Model):
 
     # Make sure tags are cleaned when saving
     def save(self, *args, **kwargs):
+        # We don't want to allow commas in tags, ever.
+        # As such, if self.name has commas, we split it,
+        # build new Tag instances for each term, and then
+        # update ourselves to be the first term.
+        name = self.name
+        if ',' in name:
+            terms = name.split(',')
+            self.name = terms[0]
+            for term in terms[1:]:
+                Tag.objects.create(name=term)
+
         self.full_clean()
         super(Tag, self).save(*args, **kwargs)
 

--- a/pulseapi/utility/userpermissions.py
+++ b/pulseapi/utility/userpermissions.py
@@ -11,17 +11,18 @@ def is_staff_address(email):
     if email is None:
         return False
 
-    parts = email.split('@')
-    domain = parts[1]
+    if '@' in email:
+        parts = email.split('@')
+        domain = parts[1]
 
-    if domain == 'mozilla.org':
-        return True
+        if domain == 'mozilla.org':
+            return True
 
-    if domain == 'mozilla.com':
-        return True
+        if domain == 'mozilla.com':
+            return True
 
-    if domain == 'mozillafoundation.org':
-        return True
+        if domain == 'mozillafoundation.org':
+            return True
 
     return False
 


### PR DESCRIPTION
This PR introduces fixes in two places:

1.  the Tag `save` definition checks to see if it contains commas, and if so rewrites its own content such that a tag for name `a,b,c` gets committed as a tag for name `a`, with two additional tags getting `get_or_create`d for 'b' and 'c'.
2. The Entry view that is used by DRF (and acts as our POST route handler) rewrites incoming tags so that a tag array where one or more tags contain commas (like `['test1', 'test2', 'test1,test2,test3']`) gets flattened (in the previous case, to `['test1','test2','test3']`)

This covers the following use cases:

1. creating Tags in the Django/Mezzanine admin view (tag with comma leads to multiple tags)
2. creating Entries in the Django/Mezzanine admin view (tags can only be picked from a multiselect box, not through freeform input)
3. creating Entries through a POST call to api/pulse/entries (tag data, if present, gets rewritten)

This fixes https://github.com/mozilla/network-pulse-api/issues/180