### PR TITLE
Fix entry-creator migrations to use dynamic models

### DIFF
--- a/pulseapi/entries/migrations/0015_copy_creators_to_ordered_creators.py
+++ b/pulseapi/entries/migrations/0015_copy_creators_to_ordered_creators.py
@@ -1,6 +1,4 @@
 from django.db import migrations
-from pulseapi.entries.models import Entry
-from pulseapi.creators.models import Creator, OrderedCreatorRecord
 
 
 def migrate_creator_data(apps, schema_editor):
@@ -11,14 +9,14 @@ def migrate_creator_data(apps, schema_editor):
     database, accessing it using an explicit link relation
     makes things much easier.
     """
-    entries = apps.get_model('entries', 'Entry').objects.all()
+    Entry = apps.get_model('entries', 'Entry')
+    OrderedCreatorRecord = apps.get_model('creators', 'OrderedCreatorRecord')
+    entries = Entry.objects.all()
     for entry in entries:
-        modern_entry = Entry.objects.get(id=entry.id)
-
         for creator in entry.creators.all():
-            link = OrderedCreatorRecord.objects.create(
-                entry=modern_entry,
-                creator=Creator.objects.get(id=creator.id)
+            OrderedCreatorRecord.objects.create(
+                entry=entry,
+                creator=creator,
             )
 
 


### PR DESCRIPTION
We referred to these models as they are currently in the code vs. using what is in the db at the time of the migration.

I tested this change and it seems to work fine. I also tested it over production data to make sure that it applies cleanly without any data loss.