### PR TITLE
add a 'customname' property to userstatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ The call response is a JSON object of the following form:
 
 ```
 {
-  username: <string: the user's full name according to Google>,
+  username: <string: the user's full name according to Google>
+  customname: <string: the user's custom name as set in their profile>
   email: <string: the user's google-login-associated email address>
   loggedin: <boolean: whether this user is logged in or not>
   moderator: <boolean: whether this logged-in user has moderation rights>

--- a/pulseapi/users/views.py
+++ b/pulseapi/users/views.py
@@ -86,8 +86,10 @@ def userstatus(request):
     user email. NOTE: these values should never be persistently
     cached by applications, for obvious reasons.
     """
-    name = False
+    username = False
+    customname = False
     email = False
+
     user = request.user
     loggedin = user.is_authenticated()
 
@@ -100,11 +102,13 @@ def userstatus(request):
         is_moderator = user.is_superuser
 
     if loggedin:
-        name = user.name
+        username = user.name
+        customname = user.profile.custom_name
         email = user.email
 
     return render(request, 'users/userstatus.json', {
-        'username': name,
+        'username': username,
+        'customname': customname,
         'email': email,
         'loggedin': loggedin,
         'moderator': is_moderator,

--- a/templates/users/userstatus.json
+++ b/templates/users/userstatus.json
@@ -1,5 +1,6 @@
 {
 {% if loggedin %}	"username": "{{ username }}",
+{% endif %}{% if customname %}	"customname": "{{ customname }}",
 {% endif %}{% if loggedin %}	"email": "{{ email }}",
 {% endif %}	"loggedin": {% if loggedin %}true{% else %}false
 {% endif %}{% if moderator %},


### PR DESCRIPTION
closes https://github.com/mozilla/network-pulse-api/issues/229 by adding a `customname` property to the `GET api/pulse/userstatus` route. This value is either missing, if the user has no custom name defined in their profile, or is a string that matches what the user set in their profile.