### PR TITLE
fix(entries): De-dupe creator with published_by_creator on posting an entry

### DIFF
--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -165,7 +165,8 @@ class EntrySerializer(serializers.ModelSerializer):
 
         if entry.published_by_creator:
             self_creator, created = Creator.objects.get_or_create(profile=profile)
-            related_creators.append(self_creator)
+            if self_creator not in related_creators:
+                related_creators.append(self_creator)
 
         for creator in related_creators:
             creator.save()


### PR DESCRIPTION
Make sure we don't duplicate the relation between entries and creators if the published_by_creator option is set AND the related_creators includes the publisher as a creator.