### PR TITLE
added icontains fallback when istartswith<page_size

### DIFF
--- a/pulseapi/creators/views.py
+++ b/pulseapi/creators/views.py
@@ -29,8 +29,8 @@ class FilterCreatorNameBackend(filters.BaseFilterBackend):
         own_name = Q(name__istartswith=search_term)
         profile_custom = Q(profile__custom_name__istartswith=search_term)
         profile_name = Q(profile__related_user__name__istartswith=search_term)
-        iexact_filter = own_name | profile_custom | profile_name
-        qs = queryset.filter(iexact_filter)
+        istartswith_filter = own_name | profile_custom | profile_name
+        qs = queryset.filter(istartswith_filter)
 
         # If the number of results returned is less than the allowed
         # page_size, we can instead rerun this using `contains` rules,
@@ -38,12 +38,13 @@ class FilterCreatorNameBackend(filters.BaseFilterBackend):
         page_size_query = request.query_params.get('page_size', None)
         page_size = int(page_size_query if page_size_query else CreatorsPagination.page_size)
         flen = len(filtered)
+
         if flen < page_size:
             own_name = Q(name__icontains=search_term)
             profile_custom = Q(profile__custom_name__icontains=search_term)
             profile_name = Q(profile__related_user__name__icontains=search_term)
             icontains_filter = own_name | profile_custom | profile_name
-            icontains_qs = queryset.filter(icontains_filter).exclude(iexact_filter)
+            icontains_qs = queryset.filter(icontains_filter).exclude(istartswith_filter)
             # make sure we keep our exact matches at the top of the result list
             qs = list(chain(qs, icontains_qs))
 

--- a/pulseapi/creators/views.py
+++ b/pulseapi/creators/views.py
@@ -37,7 +37,7 @@ class FilterCreatorNameBackend(filters.BaseFilterBackend):
         # rather than using the `startswith` rule.
         page_size_query = request.query_params.get('page_size', None)
         page_size = int(page_size_query if page_size_query else CreatorsPagination.page_size)
-        flen = len(filtered)
+        flen = len(qs)
 
         if flen < page_size:
             own_name = Q(name__icontains=search_term)


### PR DESCRIPTION
When `startswith_iexact` fails to yield more results than `page_size`, this PR adds a second search for `contains_iexact`, and tacks that to the end of the "startswith" results, to increase the likelihood of someone finding the creator they were looking for.

closes https://github.com/mozilla/network-pulse-api/issues/247