### PR TITLE
Prefetch related models when listing entries

### DIFF
--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -56,7 +56,21 @@ class EntryQuerySet(models.query.QuerySet):
             # and so if its query set is checked, it'll crash out due
             # to the absence of the associated ModerationState table.
             approved = ModerationState.objects.get(name='Approved')
-            return self.filter(moderation_state=approved)
+            return self.filter(
+                    moderation_state=approved
+                ).prefetch_related(
+                    'tags'
+                ).prefetch_related(
+                    'issues'
+                ).prefetch_related(
+                    'help_types'
+                ).select_related(
+                    'published_by'
+                ).select_related(
+                    'moderation_state'
+                )
+
+            # return self.filter(moderation_state=approved)
         except:
             print("could not make use of ModerationState!")
             return self.all()

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -3,7 +3,6 @@ import os
 
 from django.conf import settings
 from django.db import models
-from django.db.models import Prefetch
 from pulseapi.tags.models import Tag
 from pulseapi.issues.models import Issue
 from pulseapi.helptypes.models import HelpType

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -63,9 +63,10 @@ class EntryQuerySet(models.query.QuerySet):
                     'issues',
                     'help_types',
                     'published_by',
+                    'bookmarked_by',
                     'published_by__profile',
                     'moderation_state',
-                    'related_creators'
+                    'related_creators',
                 )
 
         except:

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -3,6 +3,7 @@ import os
 
 from django.conf import settings
 from django.db import models
+from django.db.models import Prefetch
 from pulseapi.tags.models import Tag
 from pulseapi.issues.models import Issue
 from pulseapi.helptypes.models import HelpType
@@ -59,18 +60,15 @@ class EntryQuerySet(models.query.QuerySet):
             return self.filter(
                     moderation_state=approved
                 ).prefetch_related(
-                    'tags'
-                ).prefetch_related(
-                    'issues'
-                ).prefetch_related(
-                    'help_types'
-                ).select_related(
-                    'published_by'
-                ).select_related(
-                    'moderation_state'
+                    'tags',
+                    'issues',
+                    'help_types',
+                    'published_by',
+                    'published_by__profile',
+                    'moderation_state',
+                    'related_creators'
                 )
 
-            # return self.filter(moderation_state=approved)
         except:
             print("could not make use of ModerationState!")
             return self.all()


### PR DESCRIPTION
This patch uses prefetch_related() on fields with related models in the `EntriesQuerySet` class

The complexity of database queries reduced from O(8n+3) to O(2n+10). There is a minor trade-off: requests returning a single entry will make 12 queries now, where it made 11 queries before.

Admittedly, this isn't ideal still, but it's an improvement. I don't believe an O(1) implementation is possible right now though. The `UserProfile` class uses an accessor method to dynamically query for the username from the related `EmailUser` class, making it impossible to prefetch. Django also seems to generate a count query for each record. I haven't dug into this count query to see if it can be prevented.