### PR TITLE
Making debugging a lot easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is the REST API server for the Mozilla Network Pulse project.
 - [Using a localhost rebinding to a "real" domain](#important-using-a-localhost-rebinding-to-a-real-domain)
 - [Environment variables](#environment-variables)
 - [Deploying to Heroku](#deploying-to-heroku)
+- [Debugging all the things](#debugging-all-the-things)
 - [Migrating data](#migrating-data)
 
 ## Resetting your database because of incompatible model changes
@@ -347,6 +348,11 @@ The following environment variables are used in this codebase
 ## Deploying to Heroku
 
 While for local development we provide a `sample.env` that you can use as default environment variables, for Heroku deployment all the above-stated variables need to be real things. **Make sure to add these to the Heroku config!**
+
+
+## Debugging all the things
+
+You may have noticed that when running with `DEBUG=TRUE`, there is a debugger toolbar to the right of any page you try to access. This is the [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/stable/), and that link will take you straight to the documentation for it on how to get the most out of it while trying to figure out what's going on when problems arise. 
 
 
 ## Resetting your database because of incompatible model changes

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -54,7 +54,7 @@ SECRET_KEY = 'Oh my god I love cake so much holy shit how amazing is cake; like,
 # Application definition
 SITE_ID = 1
 
-INSTALLED_APPS = [
+INSTALLED_APPS = list(filter(None, [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -72,11 +72,11 @@ INSTALLED_APPS = [
     'pulseapi.users',
     'pulseapi.profiles',
     'pulseapi.creators',
+    # see INTERNAL_IPS for when this actually activates when DEBUG is set:
+    'debug_toolbar' if DEBUG is True else None,
+]))
 
-    'debug_toolbar',
-]
-
-MIDDLEWARE = [
+MIDDLEWARE = list(filter(None, [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
@@ -86,10 +86,12 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # see INTERNAL_IPS for when this actually activates when DEBUG is set:
+    'debug_toolbar.middleware.DebugToolbarMiddleware' if DEBUG is True else None,
+]))
 
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-]
-
+# Whitelisting for the debug toolbar: it will not kick in except for when
+# accessed through the following domains ("IP" is a white lie, here).
 INTERNAL_IPS = [
     'localhost',
     '127.0.0.1',

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -72,6 +72,8 @@ INSTALLED_APPS = [
     'pulseapi.users',
     'pulseapi.profiles',
     'pulseapi.creators',
+
+    'debug_toolbar',
 ]
 
 MIDDLEWARE = [
@@ -84,6 +86,13 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+]
+
+INTERNAL_IPS = [
+    'localhost',
+    '127.0.0.1',
 ]
 
 AUTH_USER_MODEL = 'users.EmailUser'

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -47,3 +47,9 @@ urlpatterns = [
 
 if settings.USE_S3 is not True:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ configobj==5.0.6
 dj-database-url==0.4.1
 Django==1.10.3
 django-cors-middleware==1.3.1
+django-debug-toolbar==1.9.1
 django-environ==0.4.1
 django-filter==1.0.0
 django-storages==1.5.2


### PR DESCRIPTION
This adds the "Django Debug Toolbar" when running the API server on localhost/127.0.0.1, which makes things _so_ much easier.

![image](https://user-images.githubusercontent.com/177243/33735959-ce16034a-db45-11e7-988c-bc4cf743e7b7.png)

![image](https://user-images.githubusercontent.com/177243/33735975-dbea5f3e-db45-11e7-91de-80d7bd774768.png)
