### PR TITLE
RSS feed: Add publication date

### DIFF
--- a/pulseapi/utility/syndication.py
+++ b/pulseapi/utility/syndication.py
@@ -29,6 +29,9 @@ class RSSFeedFromPulse(Feed):
     def item_title(self, entry):
         return entry.title
 
+    def item_pubdate(self, entry):
+        return entry.created
+
     def item_description(self, entry):
         return entry.description
 


### PR DESCRIPTION
Without `item_pubdate`, every feed entries would share the same publication date the first time you add `latest` or `featured` feeds to an RSS reader.
Now, every entry has its real publication date.