### PR TITLE
Add versioning to the routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ All API routes are prefixed with `/api/pulse/`. The "pulse" might seem redundant
 
 ## How is the API versioned?
 
-All Pulse API routes are versioned via their url path so that any future changes made to data responses will not break API clients that rely on specific versions of the data. To get a specific version of the API, add the version after the API prefix (`/api/pulse/`) in the url. For e.g. if you want version 2 (v2) of the API for the `entries` route, you would query the `/api/pulse/v2/entries/` url.
+All Pulse API routes are versioned via their url path so that any future changes made to data responses will not break API clients that rely on specific versions of the data. To get a specific version of the API, add the version after the API prefix (`/api/pulse/`) in the url. For example, if you want version 2 (v2) of the API for the `entries` route, you would query the `/api/pulse/v2/entries/` url.
 
-API routes that do not include the `/api/pulse/` prefix are also versioned in the same way. For e.g. `/v1/login/` is a valid versioned route without the prefix. There are two exceptions to this - the `/rss/` prefixed routes and the `/atom/` prefied routes are not versioned.
+API routes that do not include the `/api/pulse/` prefix are also versioned in the same way. For example, `/v1/login/` is a valid versioned route without the prefix. Note however that the `/rss` and `/atom` routes are unversioned, as these are syndication endpoints.
 
 ## What happens if you don't specify an API version in the URL?
 
-To maintain legacy support, if the version is not specified in the url, we default to version 1 (v1) of the API. For e.g. querying `/api/pulse/entries/` will have the same result as querying `/api/pulse/v1/entries/`. However, we strongly recommend specifying a version in the URL as this feature may be removed in the future.
+To maintain legacy support, if the version is not specified in the url, we default to version 1 (v1) of the API. For example, querying `/api/pulse/entries/` will have the same result as querying `/api/pulse/v1/entries/`. However, we strongly recommend specifying a version in the URL as this feature may be removed in the future.
 
 ## Supported API Versions
 
@@ -55,6 +55,8 @@ To maintain legacy support, if the version is not specified in the url, we defau
 ---
 
 # General Routes
+
+All routes, including those with the `/api/pulse/` prefix should include a version in the URL (see the section on [Versioning](#versioning)) and although a URLs without the version are currently supported, versions will be made mandatory in the future.
 
 ## Login routes
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ This is the route that oauth2 login systems must point to in order to complete a
 
 ### `GET /api/pulse/v1/userstatus/`
 
-**Note:** This API route does not have a version in it since it does not rely on data in the database.
-
 This gets the current user's session information in the form of their full name and email address.
 
 The call response is a JSON object of the following form:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis Build Status](https://travis-ci.org/mozilla/network-pulse-api.svg?branch=master)](https://travis-ci.org/mozilla/network-pulse-api) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/mozilla/network-pulse-api?svg=true)](https://ci.appveyor.com/project/mozillafoundation/network-pulse-api)
+[![Travis Build Status](https://travis-ci.org/mozilla/network-pulse-api.svg?branch=master)](https://travis-ci.org/mozilla/network-pulse-api) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/mozilla/network-pulse-api?svg=true)](https://ci.appveyor.com/project/mozillafoundation/network-pulse-api) [![Current API Version](https://img.shields.io/badge/dynamic/json.svg?label=Current%20API%20Version&colorB=blue&prefix=&suffix=&query=$.latestApiVersion&uri=https%3A%2F%2Fpulse--api.mofostaging.net%2Fapi%2Fpulse%2Fstatus%2F)]
 
 # The Mozilla Foundation Network Pulse API Server
 
@@ -51,7 +51,9 @@ This will log out a user if they have an authenticated session going. Note that 
 
 This is the route that oauth2 login systems must point to in order to complete an oauth2 login process with in-browser callback URL redirection.
 
-### `GET /api/pulse/userstatus/`
+### `GET /api/pulse/v1/userstatus/`
+
+**Note:** This API route does not have a version in it since it does not rely on data in the database.
 
 This gets the current user's session information in the form of their full name and email address.
 
@@ -139,7 +141,7 @@ Please run the server and see [http://localhost:8000/entries](http://localhost:8
 This retrieves a single entry with the indicated `id` as stored in the database. As a base URL call this returns an HTML page with formatted results, as url with `?format=json` suffix this results a JSON object for use as data input to applications, webpages, etc.
 
 
-### `POST /api/pulse/entries/`
+### `POST /api/pulse/v1/entries/`
 
 POSTing of entries requires sending the following payload object:
 
@@ -213,7 +215,7 @@ This changes the moderation state for an entry to the passed moderations state. 
 
 #### `PUT /api/pulse/entries/<id=number>/feature` with optional `?format=json`
 
-This *toggles* the featured state for an entry if called by a user with moderation rights. An entry that was not featured will become featured, and already featured entries will become unfeatured when this route is called. 
+This *toggles* the featured state for an entry if called by a user with moderation rights. An entry that was not featured will become featured, and already featured entries will become unfeatured when this route is called.
 
 
 ## Entry Bookmarking
@@ -248,7 +250,7 @@ A failed post will yield
  - an HTTP 403 response if the current user is not authenticated
 
 
-### `PUT /api/pulse/entries/<id=number>/bookmark`
+### `PUT /api/pulse/v1/entries/<id=number>/bookmark`
 
 This toggles the "bookmarked" status for an entry for an authenticated user. No payload is expected, and no response is sent other than an HTTP 204 on success, HTTP 403 for not authenticated users, and HTTP 500 if something went terribly wrong on the server side.
 
@@ -260,7 +262,7 @@ This operation requires a payload of the following form:
 }
 ```
 
-### `GET /api/pulse/entries/bookmarks` with optional `?format=json`
+### `GET /api/pulse/v1/entries/bookmarks` with optional `?format=json`
 
 Get the list of all entries that have been bookmarked by the currently authenticated user. Calling this as anonymous user yields an object with property `count` equals to `0`.  As a base URL call this returns an HTML page with formatted result, as url with `?format=json` suffix this results a JSON object for use as data input to applications, webpages, etc.
 
@@ -301,7 +303,7 @@ Gets the list of internet health issues that entries can be related to. This rou
 
 ### `GET /api/pulse/issues/<Issue Name>`
 
-Fetches the same data as above, but restricted to an individual issue queried for. Note that this is a URL query, not a URL argument query, so to see the data for an issue named "Security and Privacy" for example, the corresponding URL will be `/api/pulse/issues/Security and Privacy`. 
+Fetches the same data as above, but restricted to an individual issue queried for. Note that this is a URL query, not a URL argument query, so to see the data for an issue named "Security and Privacy" for example, the corresponding URL will be `/api/pulse/issues/Security and Privacy`.
 
 
 ## Profiles
@@ -324,7 +326,7 @@ The list of profiles known to the system can be queried, but **only** in conjunc
 
 This retrieves the **editable** user profile for the currently authenticated user as stored in the database. An unauthenticated user will receive an HTTP 403 Forbidden response if they try to access this route. As a base URL call this returns an HTML page with formatted results, as url with `?format=json` suffix this results a JSON object for use as data input to applications, webpages, etc.
 
-### `PUT /api/pulse/myprofile/`
+### `PUT /api/pulse/v1/myprofile/`
 
 Allows an authenticated user to update their profile data. The payload that needs to be passed into this PUT request is:
 
@@ -485,7 +487,7 @@ While for local development we provide a `sample.env` that you can use as defaul
 
 ## Debugging all the things
 
-You may have noticed that when running with `DEBUG=TRUE`, there is a debugger toolbar to the right of any page you try to access. This is the [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/stable/), and that link will take you straight to the documentation for it on how to get the most out of it while trying to figure out what's going on when problems arise. 
+You may have noticed that when running with `DEBUG=TRUE`, there is a debugger toolbar to the right of any page you try to access. This is the [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/stable/), and that link will take you straight to the documentation for it on how to get the most out of it while trying to figure out what's going on when problems arise.
 
 
 ## Resetting your database because of incompatible model changes

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -22,7 +22,7 @@ from pulseapi.utility.userpermissions import is_staff_address
 
 
 @api_view(['PUT'])
-def toggle_bookmark(request, entryid):
+def toggle_bookmark(request, entryid, **kwargs):
     """
     Toggle whether or not this user "bookmarked" the url-indicated entry.
     This is currently defined outside of the entry class, as functionality
@@ -58,7 +58,7 @@ def toggle_bookmark(request, entryid):
 
 
 @api_view(['PUT'])
-def toggle_featured(request, entryid):
+def toggle_featured(request, entryid, **kwargs):
     """
     Toggle the featured status of an entry.
     """
@@ -83,7 +83,7 @@ def toggle_featured(request, entryid):
 
 
 @api_view(['PUT'])
-def toggle_moderation(request, entryid, stateid):
+def toggle_moderation(request, entryid, stateid, **kwargs):
     """
     Toggle the moderation state for a specific entry,
     based on moderation state id values. These values

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -184,7 +184,7 @@ API_VERSION_LIST = [
 # a version number
 API_VERSIONS = dict(API_VERSION_LIST)
 # A regex group to optionally capture a version in a url from the list of versions specified above
-VERSION_GROUP = r'((?P<version>\w+)/)?'
+VERSION_GROUP = r'((?P<version>v\d+)/)?'
 
 
 # REST Framework settings

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -180,6 +180,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 API_VERSION_LIST = [
     ('version_1', 'v1',),
 ]
+DEFAULT_VERSION = 'version_1'
 # A dictonary of api versions with the value of each version key being
 # a version number
 API_VERSIONS = dict(API_VERSION_LIST)
@@ -192,7 +193,7 @@ REST_FRAMEWORK = {
     'DEFAULT_VERSIONING_CLASS': 'pulseapi.versioning.PulseAPIVersioning',
     # Default to v1 if no version is specified in the URL
     # For e.g. /api/pulse/entries/ will default to /api/pulse/v1/
-    'DEFAULT_VERSION': API_VERSIONS['version_1'],
+    'DEFAULT_VERSION': API_VERSIONS[DEFAULT_VERSION],
     'ALLOWED_VERSIONS': list(API_VERSIONS.values())
 }
 

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -173,6 +173,30 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 
+# API Versioning
+# An ordered list of (<version key>, <version value>) tuples
+# where <version key> is the key used to identify a particular version
+# and <version value> is the value of the version that will be used in URLs
+API_VERSION_LIST = [
+    ('version_1', 'v1',),
+]
+# A dictonary of api versions with the value of each version key being
+# a version number
+API_VERSIONS = dict(API_VERSION_LIST)
+# A regex group to optionally capture a version in a url from the list of versions specified above
+VERSION_GROUP = r'((?P<version>\w+)/)?'
+
+
+# REST Framework settings
+REST_FRAMEWORK = {
+    'DEFAULT_VERSIONING_CLASS': 'pulseapi.versioning.PulseAPIVersioning',
+    # Default to v1 if no version is specified in the URL
+    # For e.g. /api/pulse/entries/ will default to /api/pulse/v1/
+    'DEFAULT_VERSION': API_VERSIONS['version_1'],
+    'ALLOWED_VERSIONS': list(API_VERSIONS.values())
+}
+
+
 #
 # CORS settings
 #

--- a/pulseapi/tests.py
+++ b/pulseapi/tests.py
@@ -232,4 +232,3 @@ class TestAPIVersioning(TestCase):
             self.version_scheme.determine_version(request, version='v100')
 
         self.assertEqual(context_manager.exception.detail, self.version_scheme.invalid_version_message)
-

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -25,6 +25,22 @@ from pulseapi.utility.syndication import (
     RSSFeedFeaturedFromPulse,
     AtomFeedFeaturedFromPulse
 )
+from pulseapi.utility.urlutils import (
+    versioned_url,
+    api_url,
+    versioned_api_url,
+)
+
+
+rss_patterns = [
+    url(r'^latest', RSSFeedLatestFromPulse()),
+    url(r'^featured', RSSFeedFeaturedFromPulse()),
+]
+
+atom_patterns = [
+    url(r'^latest', AtomFeedLatestFromPulse()),
+    url(r'^featured', AtomFeedFeaturedFromPulse()),
+]
 
 urlpatterns = [
     # admin patterns
@@ -34,27 +50,25 @@ urlpatterns = [
     url(r'^', include('pulseapi.users.urls')),
 
     # API routes
-    url(r'^api/pulse/', include('pulseapi.users.urls')),
-    url(r'^api/pulse/entries/', include('pulseapi.entries.urls')),
-    url(r'^api/pulse/profiles/', include('pulseapi.profiles.urls')),
-    url(r'^api/pulse/tags/', include('pulseapi.tags.urls')),
-    url(r'^api/pulse/issues/', include('pulseapi.issues.urls')),
-    url(r'^api/pulse/helptypes/', include('pulseapi.helptypes.urls')),
-    url(r'^api/pulse/creators/', include('pulseapi.creators.urls')),
+    url(api_url(), include('pulseapi.users.urls')),  # Non-versioned API url - r'^api/pulse/'
+    url(versioned_api_url(r'entries/'), include('pulseapi.entries.urls')),
+    url(versioned_api_url(r'profiles/'), include('pulseapi.profiles.urls')),
+    url(versioned_api_url(r'tags/'), include('pulseapi.tags.urls')),
+    url(versioned_api_url(r'issues/'), include('pulseapi.issues.urls')),
+    url(versioned_api_url(r'helptypes/'), include('pulseapi.helptypes.urls')),
+    url(versioned_api_url(r'creators/'), include('pulseapi.creators.urls')),
 
     # We provide an alternative route on the main `/api/pulse` route to allow
     # getting and editing a user's profile for the currently authenticated user
     url(
-        r'^api/pulse/myprofile/',
+        versioned_api_url(r'myprofile/'),
         UserProfileAPIView.as_view(),
         name='myprofile'
     ),
 
     # Syndication
-    url(r'^rss/latest', RSSFeedLatestFromPulse()),
-    url(r'^rss/featured', RSSFeedFeaturedFromPulse()),
-    url(r'^atom/latest', AtomFeedLatestFromPulse()),
-    url(r'^atom/featured', AtomFeedFeaturedFromPulse()),
+    url(versioned_url(r'^rss/'), include(rss_patterns)),  # r'^rss/<optional version>/'
+    url(versioned_url(r'^atom/'), include(atom_patterns)),  # r'^atom/<optional version>/'
 ]
 
 if settings.USE_S3 is not True:

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -27,30 +27,18 @@ from pulseapi.utility.syndication import (
 )
 from pulseapi.utility.urlutils import (
     versioned_url,
-    api_url,
     versioned_api_url,
 )
-
-
-rss_patterns = [
-    url(r'^latest', RSSFeedLatestFromPulse()),
-    url(r'^featured', RSSFeedFeaturedFromPulse()),
-]
-
-atom_patterns = [
-    url(r'^latest', AtomFeedLatestFromPulse()),
-    url(r'^featured', AtomFeedFeaturedFromPulse()),
-]
 
 urlpatterns = [
     # admin patterns
     url(r'^admin/', admin.site.urls),
 
     # 'homepage'
-    url(r'^', include('pulseapi.users.urls')),
+    url(versioned_url(r'^'), include('pulseapi.users.urls')),
 
     # API routes
-    url(api_url(), include('pulseapi.users.urls')),  # Non-versioned API url - r'^api/pulse/'
+    url(versioned_api_url(), include('pulseapi.users.urls')),
     url(versioned_api_url(r'entries/'), include('pulseapi.entries.urls')),
     url(versioned_api_url(r'profiles/'), include('pulseapi.profiles.urls')),
     url(versioned_api_url(r'tags/'), include('pulseapi.tags.urls')),
@@ -67,8 +55,10 @@ urlpatterns = [
     ),
 
     # Syndication
-    url(versioned_url(r'^rss/'), include(rss_patterns)),  # r'^rss/<optional version>/'
-    url(versioned_url(r'^atom/'), include(atom_patterns)),  # r'^atom/<optional version>/'
+    url(r'^rss/latest', RSSFeedLatestFromPulse()),
+    url(r'^rss/featured', RSSFeedFeaturedFromPulse()),
+    url(r'^atom/latest', AtomFeedLatestFromPulse()),
+    url(r'^atom/featured', AtomFeedFeaturedFromPulse()),
 ]
 
 if settings.USE_S3 is not True:

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -39,17 +39,17 @@ urlpatterns = [
 
     # API routes
     url(versioned_api_url(), include('pulseapi.users.urls')),
-    url(versioned_api_url(r'entries/'), include('pulseapi.entries.urls')),
-    url(versioned_api_url(r'profiles/'), include('pulseapi.profiles.urls')),
-    url(versioned_api_url(r'tags/'), include('pulseapi.tags.urls')),
-    url(versioned_api_url(r'issues/'), include('pulseapi.issues.urls')),
-    url(versioned_api_url(r'helptypes/'), include('pulseapi.helptypes.urls')),
-    url(versioned_api_url(r'creators/'), include('pulseapi.creators.urls')),
+    url(versioned_api_url('entries/'), include('pulseapi.entries.urls')),
+    url(versioned_api_url('profiles/'), include('pulseapi.profiles.urls')),
+    url(versioned_api_url('tags/'), include('pulseapi.tags.urls')),
+    url(versioned_api_url('issues/'), include('pulseapi.issues.urls')),
+    url(versioned_api_url('helptypes/'), include('pulseapi.helptypes.urls')),
+    url(versioned_api_url('creators/'), include('pulseapi.creators.urls')),
 
     # We provide an alternative route on the main `/api/pulse` route to allow
     # getting and editing a user's profile for the currently authenticated user
     url(
-        versioned_api_url(r'myprofile/'),
+        versioned_api_url('myprofile/'),
         UserProfileAPIView.as_view(),
         name='myprofile'
     ),

--- a/pulseapi/users/urls.py
+++ b/pulseapi/users/urls.py
@@ -1,7 +1,6 @@
 from django.conf.urls import url
 
 from . import views
-from pulseapi.utility.urlutils import versioned_url
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
@@ -9,8 +8,6 @@ urlpatterns = [
     url(r'^logout', views.force_logout, name='logout'),
     url(r'^oauth2callback', views.callback, name='oauthcallback'),
     url(r'^nonce', views.nonce, name="get a new nonce value"),
-    # /api/pulse/<version pattern>/userstatus
-    url(versioned_url(r'^') + 'userstatus', views.userstatus, name="get current user information"),
-    # /api/pulse/status/
+    url(r'^userstatus', views.userstatus, name="get current user information"),
     url(r'^status/', views.api_status, name='api-status'),
 ]

--- a/pulseapi/users/urls.py
+++ b/pulseapi/users/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
 from . import views
+from pulseapi.utility.urlutils import versioned_url
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
@@ -8,5 +9,8 @@ urlpatterns = [
     url(r'^logout', views.force_logout, name='logout'),
     url(r'^oauth2callback', views.callback, name='oauthcallback'),
     url(r'^nonce', views.nonce, name="get a new nonce value"),
-    url(r'^userstatus', views.userstatus, name="get current user information"),
+    # /api/pulse/<version pattern>/userstatus
+    url(versioned_url(r'^') + 'userstatus', views.userstatus, name="get current user information"),
+    # /api/pulse/status/
+    url(r'^status/', views.api_status, name='api-status'),
 ]

--- a/pulseapi/users/views.py
+++ b/pulseapi/users/views.py
@@ -9,9 +9,15 @@ from django.http import (HttpResponse, HttpResponseNotFound)
 from django.shortcuts import (redirect, render)
 from django.contrib.auth import login, logout
 from apiclient.discovery import build
+from rest_framework.decorators import api_view, renderer_classes
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
 
 from .models import EmailUser
 from pulseapi.utility.userpermissions import is_staff_address
+from pulseapi.settings import API_VERSION_LIST
+
+LATEST_API_VERSION = API_VERSION_LIST[-1][1]
 
 
 class FlowHandler:
@@ -79,7 +85,7 @@ def nonce(request):
 
 
 # API ROUTE: /userstatus
-def userstatus(request):
+def userstatus(request, **kwargs):
     """
     Get the login status associated with a session. If the
     status is "logged in", also include the user name and
@@ -265,3 +271,15 @@ def callback(request):
     return HttpResponseNotFound(
         "callback happened without an error or code query argument: this should not be possible."
     )
+
+
+@api_view()
+@renderer_classes((JSONRenderer,))
+def api_status(request):
+    """
+    Check whether the API is alive and running by returning some
+    info about the API.
+    """
+    return Response({
+        'latestApiVersion': LATEST_API_VERSION,
+    })

--- a/pulseapi/users/views.py
+++ b/pulseapi/users/views.py
@@ -69,7 +69,7 @@ def new_nonce_value(request):
 
 
 # API ROUTE: /nonce
-def nonce(request):
+def nonce(request, **kwargs):
     """
     set a new random nonce to act as form post identifier
     and inform the user what this value is so they can use
@@ -125,7 +125,7 @@ def userstatus(request, **kwargs):
 
 
 # API ROUTE: /
-def index(request):
+def index(request, **kwargs):
     """
     Initial page with a link that lets us sign in through Google
     """
@@ -140,7 +140,7 @@ def index(request):
 
 
 # API ROUTE: /login
-def start_auth(request):
+def start_auth(request, **kwargs):
     """
     Specific login call for logging in through another front-end
     """
@@ -161,7 +161,7 @@ def start_auth(request):
 
 
 # API Route: /logout (immediately directs to /)
-def force_logout(request):
+def force_logout(request, **kwargs):
     """
     An explicit logout route.
     """
@@ -202,7 +202,7 @@ def do_final_redirect(state, loggedin, msg):
 
 
 # API Route: /oauth2callback (Redirects to / on success)
-def callback(request):
+def callback(request, **kwargs):
     """
     The callback route that Google will send the user to when authentication
     finishes (with successfully, or erroneously).
@@ -275,7 +275,7 @@ def callback(request):
 
 @api_view()
 @renderer_classes((JSONRenderer,))
-def api_status(request):
+def api_status(request, **kwargs):
     """
     Check whether the API is alive and running by returning some
     info about the API.

--- a/pulseapi/users/views.py
+++ b/pulseapi/users/views.py
@@ -69,6 +69,8 @@ def new_nonce_value(request):
 
 
 # API ROUTE: /nonce
+# We include kwargs here to capture the version parameter from the url (whatever it may be named as) even though we do
+# not use it inside this function. To access the version inside this function, we use request.version.
 def nonce(request, **kwargs):
     """
     set a new random nonce to act as form post identifier
@@ -85,6 +87,8 @@ def nonce(request, **kwargs):
 
 
 # API ROUTE: /userstatus
+# We include kwargs here to capture the version parameter from the url (whatever it may be named as) even though we do
+# not use it inside this function. To access the version inside this function, we use request.version.
 def userstatus(request, **kwargs):
     """
     Get the login status associated with a session. If the
@@ -125,6 +129,8 @@ def userstatus(request, **kwargs):
 
 
 # API ROUTE: /
+# We include kwargs here to capture the version parameter from the url (whatever it may be named as) even though we do
+# not use it inside this function. To access the version inside this function, we use request.version.
 def index(request, **kwargs):
     """
     Initial page with a link that lets us sign in through Google
@@ -140,6 +146,8 @@ def index(request, **kwargs):
 
 
 # API ROUTE: /login
+# We include kwargs here to capture the version parameter from the url (whatever it may be named as) even though we do
+# not use it inside this function. To access the version inside this function, we use request.version.
 def start_auth(request, **kwargs):
     """
     Specific login call for logging in through another front-end
@@ -161,6 +169,8 @@ def start_auth(request, **kwargs):
 
 
 # API Route: /logout (immediately directs to /)
+# We include kwargs here to capture the version parameter from the url (whatever it may be named as) even though we do
+# not use it inside this function. To access the version inside this function, we use request.version.
 def force_logout(request, **kwargs):
     """
     An explicit logout route.
@@ -202,6 +212,8 @@ def do_final_redirect(state, loggedin, msg):
 
 
 # API Route: /oauth2callback (Redirects to / on success)
+# We include kwargs here to capture the version parameter from the url (whatever it may be named as) even though we do
+# not use it inside this function. To access the version inside this function, we use request.version.
 def callback(request, **kwargs):
     """
     The callback route that Google will send the user to when authentication
@@ -273,6 +285,8 @@ def callback(request, **kwargs):
     )
 
 
+# We include kwargs here to capture the version parameter from the url (whatever it may be named as) even though we do
+# not use it inside this function. To access the version inside this function, we use request.version.
 @api_view()
 @renderer_classes((JSONRenderer,))
 def api_status(request, **kwargs):

--- a/pulseapi/utility/urlutils.py
+++ b/pulseapi/utility/urlutils.py
@@ -1,0 +1,25 @@
+from pulseapi.settings import VERSION_GROUP
+
+
+def versioned_url(url_pattern=''):
+    """
+    Returns a url pattern with an optional version pattern included in it
+    For e.g. r`^myurl/` will turn into `^myurl/<version pattern>/`
+    where <version pattern> is the optional version regex pattern
+    """
+    return url_pattern + VERSION_GROUP
+
+
+def api_url(url_pattern=''):
+    """
+    Returns a url pattern prefixed with the api namespace pattern which is `^api/pulse/`
+    """
+    return r'^api/pulse/' + url_pattern
+
+
+def versioned_api_url(url_pattern=''):
+    """
+    Returns a url pattern prefixed with the api namespace pattern and
+    the optional version pattern
+    """
+    return versioned_url(r'^api/pulse/') + url_pattern

--- a/pulseapi/versioning.py
+++ b/pulseapi/versioning.py
@@ -1,0 +1,27 @@
+from rest_framework.versioning import URLPathVersioning
+from rest_framework import exceptions
+
+
+class PulseAPIVersioning(URLPathVersioning):
+    def determine_version(self, request, *args, **kwargs):
+        """
+        We override the super class' determine_version function because
+        we want the version in the url to be optional. The difference between the
+        functions is that along with using the default version if
+        the version_param IS NOT present in the kwargs, we also use
+        the default version if the version_param IS present in the kwargs
+        but is None. Hence, if a version is not specified in the url, the version_param
+        is passed in the kwargs but is set to None and will result in the
+        version being set to the default_version.
+
+        See https://groups.google.com/forum/#!topic/django-rest-framework/r7s9M-VQX_k
+        for information on whether DRF will do this on its own.
+        """
+        version = kwargs.get(self.version_param, self.default_version)
+        if version is None:
+            version = self.default_version
+
+        if not self.is_allowed_version(version):
+            raise exceptions.NotFound(self.invalid_version_message)
+
+        return version


### PR DESCRIPTION
I had to override the default url path versioning that drf provides because i think there is a bug in the way it handles optional versions in the url. I filed https://groups.google.com/forum/#!topic/django-rest-framework/r7s9M-VQX_k but haven't seen a response yet. I explained the hack in the actual versioning file.

I also added a `/api/pulse/status/` route that we can use as a healthcheck route (we can file a ticket to make it give more useful info) so that we can have a nice badge in the readme with the current API version listed (I was bored at one point so decided to experiment with it).

~One last thing left to do - add a test to test for versioning.~

## Manual testing steps
Run the server and test these routes in the browser (these have automated tests but manual will also help):
1. `/api/pulse/entries/` - should return entries
2. `/api/pulse/v1/entries/` - should return entries
3. `/api/pulse/v123/entries/` - should return a 404 with a message "Invalid version in url path"
4. `/api/pulse/version1/entries/` - should return a generic 404 not found
5. `/userstatus` - should return user status as json
6. `/v1/userstatus` - should return user status as json
7. `/v123/userstatus` - should return a 404 with a message "Invalid version in url path"
8. `/version1/userstatus` - should return a generic 404 not found
9. `/status/` - should return json with the `latestApiVersion` set to `v1`
10. `/v1/status/` - should return json with the `latestApiVersion` set to `v1`