### PR TITLE
Fix up CORS_ORIGIN_REGEX_WHITELIST parsing so that it's properly set up

### DIFF
--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -25,9 +25,10 @@ env = environ.Env(
     DEBUG=(bool, False),
     USE_S3=(bool, False),
     SSL_PROTECTION=(bool, False),
-    CORS_REGEX_WHITELIST=(tuple, ()),
     HEROKU_APP_NAME=(str, ''),
     PULSE_FRONTEND_HOSTNAME=(str, ''),
+    CORS_REGEX_WHITELIST=(str, ''),
+    CORS_ORIGIN_WHITELIST=(list, ('localhost:3000','localhost:8000','localhost:8080','test.example.com:8000','test.example.com:3000')),
 )
 SSL_PROTECTION = env('SSL_PROTECTION')
 
@@ -216,12 +217,13 @@ CORS_ORIGIN_ALLOW_ALL = False
 CORS_ALLOW_CREDENTIALS = True
 
 # and we want origin whitelisting
-CORS_ORIGIN_WHITELIST = os.getenv(
-    'CORS_ORIGIN_WHITELIST',
-    'localhost:3000,localhost:8000,localhost:8080,test.example.com:8000,test.example.com:3000'
-).split(',')
+CORS_ORIGIN_WHITELIST = env('CORS_ORIGIN_WHITELIST')
 
-CORS_ORIGIN_REGEX_WHITELIST = env('CORS_REGEX_WHITELIST')
+CORS_REGEX_WHITELIST = env('CORS_REGEX_WHITELIST')
+
+if CORS_REGEX_WHITELIST:
+    import re
+    CORS_ORIGIN_REGEX_WHITELIST = (re.compile(env('CORS_REGEX_WHITELIST')),)
 
 CSRF_TRUSTED_ORIGINS = CORS_ORIGIN_WHITELIST
 CSRF_COOKIE_HTTPONLY = env('CSRF_COOKIE_HTTPONLY', default=SSL_PROTECTION)

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -28,7 +28,13 @@ env = environ.Env(
     HEROKU_APP_NAME=(str, ''),
     PULSE_FRONTEND_HOSTNAME=(str, ''),
     CORS_REGEX_WHITELIST=(str, ''),
-    CORS_ORIGIN_WHITELIST=(list, ('localhost:3000','localhost:8000','localhost:8080','test.example.com:8000','test.example.com:3000')),
+    CORS_ORIGIN_WHITELIST=(list, (
+        'localhost:3000',
+        'localhost:8000',
+        'localhost:8080',
+        'test.example.com:8000',
+        'test.example.com:3000')
+    ),
 )
 SSL_PROTECTION = env('SSL_PROTECTION')
 


### PR DESCRIPTION
environ doesn't have the ability to load strings as tuples if they contain commas, which it considers a separator.

In order to get CORS regex whitelisting working, I have it loading in a single string from an environment file, which is compiles into a regular expression, then passes to `CORS_ORIGIN_REGEX_WHITELIST` as a tuple.

This is a first-come-first served kind of review. have at it!