### PR TITLE
limit the feed result to 20 most-recent, and only public() results

### DIFF
--- a/pulseapi/utility/syndication.py
+++ b/pulseapi/utility/syndication.py
@@ -60,7 +60,7 @@ class RSSFeedLatestFromPulse(RSSFeedFromPulse):
     description = 'Subscribe to get the latest entries from Mozilla Pulse.'
 
     def items(self):
-        return Entry.objects.order_by('-created')
+        return Entry.objects.public().order_by('-created')[:20]
 
 
 # RSS feed for featured entries
@@ -70,7 +70,7 @@ class RSSFeedFeaturedFromPulse(RSSFeedFromPulse):
     description = 'Subscribe to get the latest featured entries from Mozilla Pulse.'
 
     def items(self):
-        return Entry.objects.filter(featured=True).order_by('-created')
+        return Entry.objects.filter(featured=True).order_by('-created')[:20]
 
 
 # Atom feed for latest entries


### PR DESCRIPTION
closes https://github.com/mozilla/network-pulse-api/issues/306