### PR TITLE
Use Django 1.11 LTS

### DIFF
--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -173,6 +173,7 @@ class Entry(models.Model):
         Make plural not be wrong
         """
         verbose_name_plural = "entries"
+        ordering = ['id']
 
     def __str__(self):
         return str(self.title)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@ click==6.6
 colorama==0.3.7
 configobj==5.0.6
 dj-database-url==0.4.1
-Django==1.10.3
+Django==1.11
 django-cors-middleware==1.3.1
 django-debug-toolbar==1.9.1
 django-environ==0.4.1
-django-filter==1.0.0
+django-filter==1.1
 django-storages==1.5.2
 djangorestframework==3.5.3
 docutils==0.13.1


### PR DESCRIPTION
This PR will keep us on the latest patch version of Django 1.11 (the current LTS branch)

There are a couple fixes that had to be made, django-filters needed an update to be compatible with a new import location of a django model in 1.11, and the pagination model started throwing an `UnorderedObjectListWarning`, so I added a default ordering to the Entry model meta class, which prevented the warning.