### PR TITLE
Allow choosing creator for a profile in admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ venv
 /.vscode/
 
 # Static files from python manage.py collectstatic
-static/
+/static/
 
 # Storage for user generated files
 media/

--- a/pulseapi/creators/admin.py
+++ b/pulseapi/creators/admin.py
@@ -2,4 +2,12 @@ from django.contrib import admin
 
 from .models import Creator
 
-admin.site.register(Creator)
+
+class CreatorAdmin(admin.ModelAdmin):
+    search_fields = (
+        'name',
+        'profile__custom_name',
+        'profile__related_user__name',
+    )
+
+admin.site.register(Creator, CreatorAdmin)

--- a/pulseapi/creators/admin.py
+++ b/pulseapi/creators/admin.py
@@ -10,4 +10,5 @@ class CreatorAdmin(admin.ModelAdmin):
         'profile__related_user__name',
     )
 
+
 admin.site.register(Creator, CreatorAdmin)

--- a/pulseapi/creators/models.py
+++ b/pulseapi/creators/models.py
@@ -75,7 +75,10 @@ class Creator(models.Model):
         super(Creator, self).save(*args, **kwargs)
 
     def __str__(self):
-        return str(self.creator_name)
+        return '{name}{has_profile}'.format(
+            name=self.creator_name,
+            has_profile=' (no profile)' if not self.profile else ''
+        )
 
     class Meta:
         verbose_name = "Creator"

--- a/pulseapi/profiles/admin.py
+++ b/pulseapi/profiles/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.conf import settings
 
 from pulseapi.utility.get_admin_url import get_admin_url
 from pulseapi.profiles.forms import UserProfileAdminForm
@@ -88,6 +89,9 @@ class UserProfileAdmin(admin.ModelAdmin):
         Show the total number of bookmarks for this Entry
         """
         return instance.bookmarks_from.count()
+
+    class Media:
+        js = ['admin/js/creator-profile-rebind-protection.js', ]
 
 
 class UserBookmarksAdmin(admin.ModelAdmin):

--- a/pulseapi/profiles/admin.py
+++ b/pulseapi/profiles/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 from django.utils.html import format_html
+
 from pulseapi.utility.get_admin_url import get_admin_url
+from pulseapi.profiles.forms import UserProfileAdminForm
 from .models import (
     ProfileType,
     ProgramType,
@@ -14,6 +16,7 @@ class UserProfileAdmin(admin.ModelAdmin):
     """
     Show the profile-associated user.
     """
+    form = UserProfileAdminForm
 
     fields = (
         'is_active',
@@ -37,6 +40,7 @@ class UserProfileAdmin(admin.ModelAdmin):
         'program_year',
         'affiliation',
         'user_bio_long',
+        'creator',
     )
 
     readonly_fields = (

--- a/pulseapi/profiles/admin.py
+++ b/pulseapi/profiles/admin.py
@@ -1,6 +1,5 @@
 from django.contrib import admin
 from django.utils.html import format_html
-from django.conf import settings
 
 from pulseapi.utility.get_admin_url import get_admin_url
 from pulseapi.profiles.forms import UserProfileAdminForm

--- a/pulseapi/profiles/forms.py
+++ b/pulseapi/profiles/forms.py
@@ -28,7 +28,8 @@ class UserProfileAdminForm(forms.ModelForm):
         if instance:
             # We are updating a profile vs. creating a new one
             self.create = False
-            kwargs['initial'] = {'creator': instance.related_creator}
+            if hasattr(instance, 'related_creator'):
+                kwargs['initial'] = {'creator': instance.related_creator}
         else:
             self.create = True
 

--- a/pulseapi/profiles/forms.py
+++ b/pulseapi/profiles/forms.py
@@ -1,0 +1,76 @@
+from django import forms
+
+from pulseapi.creators.models import Creator
+
+
+class UserProfileAdminForm(forms.ModelForm):
+    """
+    We use this form for the admin view of a profile so that
+    we can add new read-write fields that we want in the admin view
+    that aren't present in the model, e.g. reverse-relation fields.
+    Any model field that needs to show up in the admin should be defined
+    in the fields for the UserProfileAdmin. Only additional non-model
+    fields or fields that require custom logic should be defined in this form.
+    """
+    creator = forms.ModelChoiceField(
+        required=False,
+        empty_label='(Create one for me)',
+        queryset=Creator.objects.all(),
+        help_text='The creator associated with this profile.<br />'
+                  'NOTE: If you set this to a creator that is already associated with another profile, '
+                  'the creator will no longer be attached to that profile and will '
+                  'instead be associated with the current profile instead.',
+    )
+
+    def __init__(self, *args, **kwargs):
+        instance = kwargs.get('instance', None)
+
+        if instance:
+            # We are updating a profile vs. creating a new one
+            self.create = False
+            kwargs['initial'] = {'creator': instance.related_creator}
+        else:
+            self.create = True
+
+        super().__init__(*args, **kwargs)
+
+    def save(self, commit=True):
+        '''
+        Current hack for making sure that we can choose a creator for a profile
+        via the admin. Unfortunately, we cannot circumvent the post_save hook
+        that automatically creates a Creator for a new profile, so instead,
+        we pass along the selected creator to the post_save so that it knows to
+        use the selected creator instead of creating a new Creator.
+        For updating profiles, the post_save logic isn't triggered and hence,
+        we handle the binding of the profile to the selected Creator here, but
+        we have to wait for the profile to be saved first to associate it with
+        the Creator.
+        '''
+        instance = super().save(commit=False)
+        # Get the chosen creator
+        creator = self.cleaned_data['creator']
+
+        # If this is a new profile and a creator was chosen, pass it along
+        # to the post_save hook.
+        if creator is not None and self.create:
+            instance._creator = creator
+
+        instance.save()
+
+        # Handle updating a profile
+        if not self.create:
+            # Make sure that a different existing creator was set
+            if creator is not None and creator.profile != instance:
+                # First unbind the creator already related to this profile
+                # We use a safe approach here to simply unbind vs. delete the creator
+                # So that entries that refer to that creator don't break.
+                Creator.objects.filter(pk=instance.related_creator.pk).update(profile=None, name=instance.name)
+                # Rebind to the new creator
+                creator.profile = instance
+                creator.save()
+            # Create a new Creator if that was what was chosen
+            if creator is None:
+                creator = Creator.objects.get_or_create(profile=instance)
+
+        return instance
+

--- a/pulseapi/profiles/forms.py
+++ b/pulseapi/profiles/forms.py
@@ -73,4 +73,3 @@ class UserProfileAdminForm(forms.ModelForm):
                 creator = Creator.objects.get_or_create(profile=instance)
 
         return instance
-

--- a/pulseapi/profiles/signals.py
+++ b/pulseapi/profiles/signals.py
@@ -10,5 +10,14 @@ def create_creator_for_profile(sender, **kwargs):
     """
     Automatically create a corresponding Creator instance for every profile that is created.
     """
+    instance = kwargs.get('instance')
+    # This will check to see if a creator was passed in and use that
+    # to bind to the current profile instead of creating a new one
+    creator = instance._creator if hasattr(instance, '_creator') else None
+
     if kwargs.get('created', False) and not kwargs.get('raw', False):
-        Creator.objects.get_or_create(profile=kwargs.get('instance'))
+        if creator is not None:
+            creator.profile = instance
+            creator.save()
+        else:
+            Creator.objects.get_or_create(profile=kwargs.get('instance'))

--- a/pulseapi/profiles/static/admin/js/creator-profile-rebind-protection.js
+++ b/pulseapi/profiles/static/admin/js/creator-profile-rebind-protection.js
@@ -1,0 +1,13 @@
+document.addEventListener("DOMContentLoaded", function(e) {
+  var selector = document.getElementById("id_creator");
+  selector.addEventListener("change", function(e) {
+    result = window.confirm(
+      "Are you sure you want to change this binding?\n\n" +
+      "WARNING: If you set this to a creator that is already associated with another profile, that profile will lose its association to the selected creator and all entries that referenced that creator will now link to this profile."
+    );
+
+    if (!result) {
+      e.preventDefault();
+    }
+  });
+});

--- a/pulseapi/profiles/static/admin/js/creator-profile-rebind-protection.js
+++ b/pulseapi/profiles/static/admin/js/creator-profile-rebind-protection.js
@@ -3,7 +3,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
   selector.addEventListener("change", function(e) {
     result = window.confirm(
       "Are you sure you want to change this binding?\n\n" +
-      "WARNING: If you set this to a creator that is already associated with another profile, that profile will lose its association to the selected creator and all entries that referenced that creator will now link to this profile."
+      "WARNING: This change CANNOT be undone. If you set this to a creator that is already associated with another profile, that profile will lose its association to the selected creator and all entries that referenced that creator will now link to this profile."
     );
 
     if (!result) {


### PR DESCRIPTION
This allows you to choose a creator for a profile. This is by no means a final solution (it also has some bad performance issues) but is meant to unblock the fellowships work.

Things to test in the admin:
1. Create a new profile and make sure you can let it automatically create a Creator for you.
2. Create a new profile and make sure you can select an existing Creator to associate with this profile. Check that the previous profile that the existing Creator was associated with is no longer associated with that profile.
3. Update an existing profile and make sure that you can change its creator to another existing Creator. Make sure that the other existing Creator is now no longer associated to the profile it was previously associated with (if it wasn't an orphan profile) and that the previous Creator that was associated with the profile you are updating has been orphaned (it'll say 'no profile' next to the creator name but will have the same name as your profile, i.e. you should see two creators with the same name as your profile, but one will have 'no profile' next to its name).
4. Update an existing profile and make sure that you can change its creator to the option that automatically creates a new creator.

cc @xmatthewx (do the above test cases cover your use case?).

