### PR TITLE
Add route for profile favorites

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To maintain legacy support, if the version is not specified in the url, we defau
 
 ## Supported API Versions
 
+- Version 2 - `/api/pulse/v2/` and `/v2/`
 - Version 1 - `/api/pulse/v1/` and `/v1/`
 
 ---
@@ -342,7 +343,25 @@ Fetches the same data as above, but restricted to an individual issue queried fo
 
 ### `GET /api/pulse/profiles/<id=number>/` with optional `?format=json`
 
-This retrieves a single user profile with the indicated `id` as stored in the database. Any profile can be retrieved using this route even without being authenticated. The payload returned by this route also includes an array of entries published (`published_entries`) by the user owning this profile and an array of entries created (`created_entries`) by this profile (as defined by other users when creating entries). As a base URL call this returns an HTML page with formatted results, as url with `?format=json` suffix this results a JSON object for use as data input to applications, webpages, etc.
+This retrieves a single user profile with the indicated `id` as stored in the database. Any profile can be retrieved using this route even without being authenticated. As a base URL call this returns an HTML page with formatted results, as url with `?format=json` suffix this results a JSON object for use as data input to applications, webpages, etc.
+
+#### Version 2 - `GET /api/pulse/v2/profiles/<id=number>/` with optional `?format=json`
+
+The response only contains profile information without any information about entries related to the profile (use [GET /api/pulse/profiles/<id=number>/entries/?...](#get-apipulseprofilesidnumberentries-with-filter-arguments-and-optional-formatjsong) for retrieving the entries).
+
+#### Version 1 - `GET /api/pulse/v1/profiles/<id=number>/` with optional `?format=json`
+
+The payload returned by this route also includes an array of entries published (`published_entries`) by the user owning this profile and an array of entries created (`created_entries`) by this profile (as defined by other users when creating entries).
+
+### `GET /api/pulse/profiles/<id=number>/entries/?...` with filter arguments, and optional `?format=json`
+
+This retrieves a list of entries associated with a profile specified by `id`. The entries returned can be filtered based on any combination of the following query arguments:
+
+- `created`: Include a list of entries (with their `related_creators`) created by this profile.
+- `published`: Include a list of entries (with their `related_creators`) published by this profile.
+- `favorited`: Include a list of entries (with their `related_creators`) favorited/bookmarked by this profile.
+
+If none of the filters are specified, all entries associated with the profile will be returned.
 
 ### `GET /api/pulse/profiles/?...` with a filter arguments, and optional `format=json`
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ This retrieves a list of entries associated with a profile specified by `id`. Th
 - `published`: Include a list of entries (with their `related_creators`) published by this profile.
 - `favorited`: Include a list of entries (with their `related_creators`) favorited/bookmarked by this profile.
 
-If none of the filters are specified, all entries associated with the profile will be returned.
+If none of the filters are specified, only the number of entries associated with the profile will be returned.
 
 ### `GET /api/pulse/profiles/?...` with a filter arguments, and optional `format=json`
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ This retrieves a list of entries associated with a profile specified by `id`. Th
 
 If none of the filters are specified, only the number of entries associated with the profile will be returned.
 
-### `GET /api/pulse/profiles/?...` with a filter arguments, and optional `format=json`
+### `GET /api/pulse/profiles/?...` with filter arguments, and optional `format=json`
 
 The list of profiles known to the system can be queried, but **only** in conjunction with one or more of three query arguments:
 
@@ -371,7 +371,17 @@ The list of profiles known to the system can be queried, but **only** in conjunc
 - `program_type`: filter the list by program types `media fellow`, `open web fellow`, `science fellow`, `senior fellow`, or `tech policy fellow`.
 - `program_year`: filter the list by program year in the range 2015-2019 (inclusive).
 
-You can sort these results using the `ordering` query param, passing it either `custom_name` or `program_year` (negated like `-custom_name` to reverse)
+You can sort these results using the `ordering` query param, passing it either `custom_name` or `program_year` (negated like `-custom_name` to reverse).
+
+The resulting payload content differs based on the version of the API you use.
+
+#### Version 2 - `GET /api/pulse/v2/profiles/?...` with filter arguments, and optional `format=json`
+
+The response only contains profile information without any information about entries related to the profile (use [GET /api/pulse/profiles/<id=number>/entries/?...](#get-apipulseprofilesidnumberentries-with-filter-arguments-and-optional-formatjsong) for retrieving the entries for each profile individually).
+
+#### Version 1 - `GET /api/pulse/v1/profiles/?...` with filter arguments, and optional `format=json`
+
+The payload returned by this route also includes an array of entries published (`published_entries`) by the user owning this profile and an array of entries created (`created_entries`) by this profile (as defined by other users when creating entries).
 
 ### `GET /api/pulse/myprofile/` with optional `?format=json`
 

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -73,9 +73,10 @@ class EntryQuerySet(models.query.QuerySet):
             'help_types',
             'published_by',
             'bookmarked_by',
+            'bookmarked_by__profile__related_user',
             'published_by__profile',
             'moderation_state',
-            'related_creators',
+            'related_creators__creator__profile__related_user',
         )
 
 

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -47,7 +47,7 @@ class EntryQuerySet(models.query.QuerySet):
 
     def public(self):
         """
-        Return all entries to start
+        Return all entries that have been approved
         """
         try:
             # This has to happen in a try/catch, so that migrations
@@ -56,23 +56,27 @@ class EntryQuerySet(models.query.QuerySet):
             # and so if its query set is checked, it'll crash out due
             # to the absence of the associated ModerationState table.
             approved = ModerationState.objects.get(name='Approved')
-            return self.filter(
-                    moderation_state=approved
-                ).prefetch_related(
-                    'tags',
-                    'issues',
-                    'help_types',
-                    'published_by',
-                    'bookmarked_by',
-                    'bookmarked_by__profile__related_user',
-                    'published_by__profile',
-                    'moderation_state',
-                    'related_creators__creator__profile__related_user',
-                )
+            return self.filter(moderation_state=approved)
 
         except:
             print("could not make use of ModerationState!")
             return self.all()
+
+    def with_related(self):
+        """
+        Return all entries with their related data as separate queries
+        """
+
+        return self.prefetch_related(
+            'tags',
+            'issues',
+            'help_types',
+            'published_by',
+            'bookmarked_by',
+            'published_by__profile',
+            'moderation_state',
+            'related_creators',
+        )
 
 
 class Entry(models.Model):

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -206,7 +206,7 @@ class EntryView(RetrieveAPIView):
     A view to retrieve individual entries
     """
 
-    queryset = Entry.objects.public()
+    queryset = Entry.objects.public().with_related()
     serializer_class = EntrySerializer
     pagination_class = None
     parser_classes = (
@@ -247,7 +247,7 @@ class BookmarkedEntries(ListAPIView):
 
             # This var was set, but never used. Commented off
             # rather than deleted just in case:
-            # queryset = Entry.objects.public()
+            # queryset = Entry.objects.public().with_related()
 
             def bookmark_entry(id):
                 entry = None
@@ -364,7 +364,7 @@ class EntriesListView(ListCreateAPIView):
                     queryset = Entry.objects.filter(moderation_state=mvalue)
 
         if queryset is False:
-            queryset = Entry.objects.public()
+            queryset = Entry.objects.public().with_related()
 
         # If the query was for a set of specific entries,
         # filter the query set further.

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -181,7 +181,8 @@ class UserProfileEntriesSerializer(serializers.Serializer):
     - `published` - List of entries published by the profile
     - `favorited` - List of entries favorited/bookmarked by the profile
     """
-    def serialize_entry(self, entry):
+    @staticmethod
+    def serialize_entry(entry):
         serialized_entry = EntryBaseSerializer(entry).data
         serialized_entry['related_creators'] = EntryOrderedCreatorSerializer(
             entry.related_creators,

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -171,6 +171,16 @@ class UserProfilePublicWithEntriesSerializer(UserProfilePublicSerializer):
 
 
 class UserProfileEntriesSerializer(serializers.Serializer):
+    """
+    Serializes entries related to a profile based on the requested
+    entry types.
+
+    Add any combination of the following parameters to the serializer context
+    to request specific types of entries in the serialized data:
+    - `created` - List of entries created by the profile
+    - `published` - List of entries published by the profile
+    - `favorited` - List of entries favorited/bookmarked by the profile
+    """
     def to_representation(self, instance):
         data = {}
         context = self.context

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -179,33 +179,34 @@ class UserProfileEntriesSerializer(serializers.Serializer):
         include_favorited = context.get('favorited', False)
         include_all = not (include_created or include_published or include_favorited)
 
-        entries = Entry.objects.public()
-
         if include_created or include_all:
+            entries = Entry.objects.public().prefetch_related(
+                'related_creators__creator__profile__related_user'
+            )
             ordered_creators = (
                 OrderedCreatorRecord.objects
-                .filter(creator=instance.related_creator)
                 .prefetch_related(Prefetch('entry', queryset=entries))
+                .filter(creator=instance.related_creator)
             )
             data['created'] = []
             for ordered_creator in ordered_creators:
                 entry = ordered_creator.entry
                 serialized_entry = EntryBaseSerializer(entry).data
                 serialized_entry['related_creators'] = EntryOrderedCreatorSerializer(
-                    OrderedCreatorRecord.objects
-                    .select_related('creator', 'creator__profile')
-                    .filter(entry=entry),
-                    many=True,
+                    entry.related_creators,
+                    many=True
                 ).data
                 data['created'].append(serialized_entry)
 
         if include_published or include_all:
+            entries = Entry.objects.public()
             data['published'] = EntryBaseSerializer(
                 entries.filter(published_by=instance.user) if instance.user else [],
                 many=True
             ).data
 
         if include_favorited or include_all:
+            entries = Entry.objects.public()
             user_bookmarks = UserBookmarks.objects.filter(profile=instance)
             data['favorited'] = EntryBaseSerializer([
                 bookmark.entry for bookmark in

--- a/pulseapi/profiles/urls.py
+++ b/pulseapi/profiles/urls.py
@@ -5,9 +5,15 @@ from pulseapi.profiles.views import (
     UserProfileListAPIView,
     UserProfilePublicAPIView,
     UserProfilePublicSelfAPIView,
+    UserProfileEntriesAPIView,
 )
 
 urlpatterns = [
+    url(
+        r'^(?P<pk>[0-9]+)/entries/',
+        UserProfileEntriesAPIView.as_view(),
+        name='profile-entries',
+    ),
     url(
         r'^(?P<pk>[0-9]+)/',
         UserProfilePublicAPIView.as_view(),

--- a/pulseapi/profiles/urls.py
+++ b/pulseapi/profiles/urls.py
@@ -10,12 +10,12 @@ from pulseapi.profiles.views import (
 
 urlpatterns = [
     url(
-        r'^(?P<pk>[0-9]+)/entries/',
+        r'^(?P<pk>[0-9]+)/entries/$',
         UserProfileEntriesAPIView.as_view(),
         name='profile-entries',
     ),
     url(
-        r'^(?P<pk>[0-9]+)/',
+        r'^(?P<pk>[0-9]+)/$',
         UserProfilePublicAPIView.as_view(),
         name='profile',
     ),

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -181,8 +181,6 @@ class UserProfileListAPIView(ListAPIView):
       program_year=
       ordering=(custom_name, program_year) or negative (e.g. -custom_name) to reverse.
     """
-    serializer_class = UserProfilePublicSerializer
-
     filter_backends = (
         filters.DjangoFilterBackend,
         filters.OrderingFilter,
@@ -193,3 +191,9 @@ class UserProfileListAPIView(ListAPIView):
     filter_class = ProfileCustomFilter
 
     queryset = UserProfile.objects.all()
+
+    def get_serializer_class(self):
+        if self.request and self.request.version == settings.API_VERSIONS['version_2']:
+            return UserProfilePublicSerializer
+
+        return UserProfilePublicWithEntriesSerializer

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -96,7 +96,13 @@ class UserProfileEntriesAPIView(APIView):
         that can be filtered by entries that this profile - was
         a creator on, was a publisher of, or favorited.
         """
-        profile = get_object_or_404(UserProfile.objects.prefetch_related('related_creator'), pk=pk)
+        profile = get_object_or_404(
+            UserProfile.objects.select_related(
+                'related_creator',
+                'related_user'
+            ),
+            pk=pk,
+        )
         query = request.query_params
 
         return Response(

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -190,7 +190,13 @@ class UserProfileListAPIView(ListAPIView):
 
     filter_class = ProfileCustomFilter
 
-    queryset = UserProfile.objects.all()
+    queryset = UserProfile.objects.all().prefetch_related(
+        'related_user',
+        'issues',
+        'profile_type',
+        'program_type',
+        'program_year'
+    )
 
     def get_serializer_class(self):
         if self.request and self.request.version == settings.API_VERSIONS['version_2']:

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -96,7 +96,7 @@ class UserProfileEntriesAPIView(APIView):
         that can be filtered by entries that this profile - was
         a creator on, was a publisher of, or favorited.
         """
-        profile = get_object_or_404(UserProfile.objects.only('id').prefetch_related('related_creator'), pk=pk)
+        profile = get_object_or_404(UserProfile.objects.prefetch_related('related_creator'), pk=pk)
         query = request.query_params
 
         return Response(

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -83,16 +83,14 @@ class UserProfileAPIView(RetrieveUpdateAPIView):
         return super(UserProfileAPIView, self).put(request, *args, **kwargs)
 
 
+# We don't inherit from a generic API view class since we're customizing
+# the get functionality more than the generic would allow.
 class UserProfileEntriesAPIView(APIView):
-    """
-    We don't inherit from a generic API view class since we're customizing
-    the get functionality more than the generic would allow.
-    """
     authentication_classes = []
 
     def get(self, request, pk, **kwargs):
         """
-        Return a list entries associated with this profile
+        Return a list of entries associated with this profile
         that can be filtered by entries that this profile - was
         a creator on, was a publisher of, or favorited.
         """

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -201,6 +201,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 # and <version value> is the value of the version that will be used in URLs
 API_VERSION_LIST = [
     ('version_1', 'v1',),
+    ('version_2', 'v2',),
 ]
 DEFAULT_VERSION = 'version_1'
 # A dictonary of api versions with the value of each version key being

--- a/pulseapi/tests.py
+++ b/pulseapi/tests.py
@@ -164,6 +164,8 @@ class PulseMemberTestCase(TestCase):
     """
     A test case wrapper for "plain users" without any staff or admin rights
     """
+    maxDiff = None
+
     def setUp(self):
         boostrap(
             self,
@@ -179,6 +181,8 @@ class PulseStaffTestCase(TestCase):
     """
     A test case wrapper for "staff" users, due to having a mozilla login
     """
+    maxDiff = None
+
     def setUp(self):
         boostrap(
             self,

--- a/pulseapi/utility/management/commands/load_fake_data.py
+++ b/pulseapi/utility/management/commands/load_fake_data.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
 
         # Select random published entries and bookmark them for 1 to 10 users
         self.stdout.write('Creating bookmarks')
-        approved_entries = Entry.objects.public()
+        approved_entries = Entry.objects.public().with_related()
         for e in sample(list(approved_entries), k=len(approved_entries)//2):
             [UserBookmarksFactory.create(entry=e) for i in range(randint(1, 10))]
 

--- a/pulseapi/utility/syndication.py
+++ b/pulseapi/utility/syndication.py
@@ -60,7 +60,7 @@ class RSSFeedLatestFromPulse(RSSFeedFromPulse):
     description = 'Subscribe to get the latest entries from Mozilla Pulse.'
 
     def items(self):
-        return Entry.objects.public().order_by('-created')[:20]
+        return Entry.objects.public().with_related().order_by('-created')[:20]
 
 
 # RSS feed for featured entries


### PR DESCRIPTION
Fix #304 

This adds a route to get entries associated for a profile based on the querystring - `?created`, `?published`, or `?favorited`. Refer to the linked ticket to see the different routes (getting a profile without these entries is now versioned under `v2/`). This PR also includes optimizations for the queries needed to fetch these entries - the previous queries ran under O(n) + C time where C is a pretty large constant, the new queries run under O(1) time - 8 queries for created and favorited entries and 7 queries for published entries.

If none of the params are passed via querystring, it just returns the number of entries associated with that profile (all created, published, favorited, de-duped).

cc @patjouk this is the work I have so far