### PR TITLE
Use customized django admin view for users

### DIFF
--- a/pulseapi/users/admin.py
+++ b/pulseapi/users/admin.py
@@ -2,6 +2,7 @@
 Admin setings for EmailUser app
 """
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import Group
 from django.utils.html import format_html
 
@@ -13,29 +14,44 @@ from pulseapi.utility.get_admin_url import get_admin_url
 from .admin_group_editing import GroupAdmin
 
 
-class EmailUserAdmin(admin.ModelAdmin):
+class EmailUserAdmin(UserAdmin):
     """
     Show a list of entries a user has submitted in the EmailUser Admin app
     """
-    fields = (
-        'password',
-        'last_login',
-        'email',
-        'name',
-        'is_staff',
-        'is_superuser',
-        'user_profile',
-        'entries',
+    fieldsets = (
+        (None, {
+            'fields': (
+                'user_password',
+                'last_login',
+                'email',
+                'name',
+                'is_staff',
+                'is_superuser',
+                'user_profile',
+                'entries',
+            )
+        }),
     )
 
     readonly_fields = (
         'entries',
         'user_profile',
         'name',
+        'user_password',
     )
 
     list_display = ('name', 'email', 'profile',)
+    list_filter = ('is_staff', 'is_superuser', 'groups',)
     search_fields = ('name', 'email',)
+    ordering = ('name',)
+
+    def user_password(self, instance):
+        return format_html(
+            '<div>Raw passwords are not stored, so there is no '
+            'way to see this user\'s password, but you can change the password '
+            'using <a href="../password/">this form</a>.</div>'
+        )
+    user_password.short_description = 'Password'
 
     def entries(self, instance):
         entries = Entry.objects.filter(published_by=instance)


### PR DESCRIPTION
We should have been inheriting from the default django user model admin so I changed that here. Since we have our own properties for the user model, I had to tweak some of the admin options to override the defaults - `fieldsets`, `list_filter`, and `ordering`