### PR TITLE
Fix Group Creation so that the user relations don't fail upon save

### DIFF
--- a/pulseapi/users/admin_group_editing.py
+++ b/pulseapi/users/admin_group_editing.py
@@ -41,14 +41,7 @@ class GroupAdminForm(forms.ModelForm):
         self.instance.user_set = self.cleaned_data['users']
 
     def save(self, *args, **kwargs):
-        # Default save but no commit.
-        instance = super(GroupAdminForm, self).save()
-
-        # Save many-to-many user relations
-        self.save_m2m()
-
-        return instance
-
+        return super(GroupAdminForm, self).save()
 
 # Create a new Group admin.
 class GroupAdmin(admin.ModelAdmin):

--- a/pulseapi/users/admin_group_editing.py
+++ b/pulseapi/users/admin_group_editing.py
@@ -43,6 +43,7 @@ class GroupAdminForm(forms.ModelForm):
     def save(self, *args, **kwargs):
         return super(GroupAdminForm, self).save()
 
+
 # Create a new Group admin.
 class GroupAdmin(admin.ModelAdmin):
     # Use our custom form.

--- a/pulseapi/users/admin_group_editing.py
+++ b/pulseapi/users/admin_group_editing.py
@@ -37,13 +37,16 @@ class GroupAdminForm(forms.ModelForm):
             # Populate the users field with the current Group users.
             self.fields['users'].initial = self.instance.user_set.all()
 
+    def save_m2m(self):
+        self.instance.user_set = self.cleaned_data['users']
+
     def save(self, *args, **kwargs):
         # Default save but no commit.
-        instance = super(GroupAdminForm, self).save(commit=False)
-        # Add the users to the Group.
-        instance.user_set = self.cleaned_data['users']
-        # Call save.
-        instance.save()
+        instance = super(GroupAdminForm, self).save()
+
+        # Save many-to-many user relations
+        self.save_m2m()
+
         return instance
 
 


### PR DESCRIPTION
This PR fixes an uncaught exception causing internal server errors when attempting to create a new group. The problem was that the many-to-many relation between a user and a group could not get saved because the group instance was created with `commit=False`. Adding a `save_m2m` method to the Form model and assigning the "cleaned" user data from the form to the instance there seems to magically solve the problem somewhere inside django... yay!

Was able to use this StackOverflow post to understand and fix the issue: https://stackoverflow.com/a/39648244