### PR TITLE
Show which profiles have extended info in admin

### DIFF
--- a/pulseapi/profiles/admin.py
+++ b/pulseapi/profiles/admin.py
@@ -56,12 +56,14 @@ class UserProfileAdmin(admin.ModelAdmin):
         'program_type',
         'program_year',
         'user_account',
+        'enable_extended_information',
     )
 
     list_filter = (
         'profile_type',
         'program_type',
         'program_year',
+        'enable_extended_information',
     )
 
     search_fields = (


### PR DESCRIPTION
Some profiles' extended info aren't showing up in the pulse results. Adding this column allows us to filter and quickly see which need to be changed.