### PR TITLE
Generate a configurable amount of fellows in varying years and programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Two options are available:
 
 - `--delete`: Delete bookmarks, creators, entries, profiles, tags and users from the database,
 - `--seed`: A seed value to pass to Faker before generating data.
+- `--fellows-count`: The number of fellows to generate per program type, per year. Defaults to 3
 
 ## Running the server
 

--- a/pulseapi/utility/management/commands/generate_fellows.py
+++ b/pulseapi/utility/management/commands/generate_fellows.py
@@ -7,6 +7,7 @@ from pulseapi.profiles.models import ProgramYear, ProgramType, ProfileType
 from pulseapi.profiles.factory import ExtendedUserProfileFactory
 from pulseapi.users.factory import BasicEmailUserFactory
 
+
 class Command(BaseCommand):
     help = 'Generate fellowship profiles for testing purposes'
 

--- a/pulseapi/utility/management/commands/generate_fellows.py
+++ b/pulseapi/utility/management/commands/generate_fellows.py
@@ -1,0 +1,40 @@
+"""
+Insert a configurable number of fellowship profiles into the database
+"""
+from django.core.management.base import BaseCommand
+
+from pulseapi.profiles.models import ProgramYear, ProgramType, ProfileType
+from pulseapi.profiles.factory import ExtendedUserProfileFactory
+from pulseapi.users.factory import BasicEmailUserFactory
+
+class Command(BaseCommand):
+    help = 'Generate fellowship profiles for testing purposes'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--fellowsCount',
+            action='store',
+            type=int,
+            default=3,
+            dest='fellows_count',
+            help='The number of fellows to generate per program type, per year'
+        )
+
+    def handle(self, *args, **options):
+        self.stdout.write('Creating Fellows')
+        fellows_profile_type = ProfileType.objects.get(value='fellow')
+        program_years = ProgramYear.objects.all()
+        program_types = ProgramType.objects.all()
+
+        for program_year in program_years:
+            for program_type in program_types:
+                for i in range(options['fellows_count']):
+                    ext_profile = ExtendedUserProfileFactory(
+                        profile_type=fellows_profile_type,
+                        program_year=program_year,
+                        program_type=program_type
+                    )
+                    BasicEmailUserFactory.create(
+                        active=True,
+                        profile=ext_profile
+                    )

--- a/pulseapi/utility/management/commands/load_fake_data.py
+++ b/pulseapi/utility/management/commands/load_fake_data.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            '--fellowsCount',
+            '--fellows-count',
             action='store',
             type=int,
             default=3,

--- a/pulseapi/utility/management/commands/load_fake_data.py
+++ b/pulseapi/utility/management/commands/load_fake_data.py
@@ -36,11 +36,11 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            '--fellowsPerType',
+            '--fellowsCount',
             action='store',
             type=int,
             default=3,
-            dest='fellows_per_type',
+            dest='fellows_count',
             help='The number of fellows to generate per program type, per year'
         )
 
@@ -76,7 +76,7 @@ class Command(BaseCommand):
 
         for program_year in program_years:
             for program_type in program_types:
-                for i in range(options['fellows_per_type']):
+                for i in range(options['fellows_count']):
                     ext_profile = ExtendedUserProfileFactory(
                         profile_type=fellows_profile_type,
                         program_year=program_year,

--- a/pulseapi/utility/management/commands/load_fake_data.py
+++ b/pulseapi/utility/management/commands/load_fake_data.py
@@ -8,11 +8,11 @@ from django.core.management.base import BaseCommand
 from django.core.management import call_command
 
 from pulseapi.entries.models import Entry
-from pulseapi.profiles.models import ProgramYear, ProgramType, ProfileType
+
 # Factories
 from pulseapi.creators.factory import OrderedCreatorRecordFactory, CreatorFactory
 from pulseapi.entries.factory import BasicEntryFactory, GetInvolvedEntryFactory
-from pulseapi.profiles.factory import UserBookmarksFactory, ExtendedUserProfileFactory
+from pulseapi.profiles.factory import UserBookmarksFactory
 from pulseapi.tags.factory import TagFactory
 from pulseapi.users.factory import BasicEmailUserFactory, MozillaEmailUserFactory
 
@@ -69,23 +69,9 @@ class Command(BaseCommand):
         BasicEmailUserFactory.create(use_custom_name=True)
         BasicEmailUserFactory.create(use_custom_name=True, active=True)
 
-        self.stdout.write('Creating Fellows')
-        fellows_profile_type = ProfileType.objects.get(value='fellow')
-        program_years = ProgramYear.objects.all()
-        program_types = ProgramType.objects.all()
-
-        for program_year in program_years:
-            for program_type in program_types:
-                for i in range(options['fellows_count']):
-                    ext_profile = ExtendedUserProfileFactory(
-                        profile_type=fellows_profile_type,
-                        program_year=program_year,
-                        program_type=program_type
-                    )
-                    BasicEmailUserFactory.create(
-                        active=True,
-                        profile=ext_profile
-                    )
+        # Call the generate_fellows command to handle fellows generation
+        fellows_count = options['fellows_count']
+        call_command('generate_fellows', f'--fellowsCount={fellows_count}')
 
         self.stdout.write('Creating Mozilla users')
         MozillaEmailUserFactory.create()

--- a/pulseapi/utility/management/commands/load_fake_data.py
+++ b/pulseapi/utility/management/commands/load_fake_data.py
@@ -8,11 +8,11 @@ from django.core.management.base import BaseCommand
 from django.core.management import call_command
 
 from pulseapi.entries.models import Entry
-
+from pulseapi.profiles.models import ProgramYear, ProgramType, ProfileType
 # Factories
 from pulseapi.creators.factory import OrderedCreatorRecordFactory, CreatorFactory
 from pulseapi.entries.factory import BasicEntryFactory, GetInvolvedEntryFactory
-from pulseapi.profiles.factory import UserBookmarksFactory
+from pulseapi.profiles.factory import UserBookmarksFactory, ExtendedUserProfileFactory
 from pulseapi.tags.factory import TagFactory
 from pulseapi.users.factory import BasicEmailUserFactory, MozillaEmailUserFactory
 
@@ -35,6 +35,15 @@ class Command(BaseCommand):
             help='A seed value to pass to Faker before generating data'
         )
 
+        parser.add_argument(
+            '--fellowsPerType',
+            action='store',
+            type=int,
+            default=3,
+            dest='fellows_per_type',
+            help='The number of fellows to generate per program type, per year'
+        )
+
     def handle(self, *args, **options):
         if options['delete']:
             call_command('flush_data')
@@ -55,11 +64,28 @@ class Command(BaseCommand):
         self.stdout.write('Creating generic users')
         BasicEmailUserFactory.create()
         [BasicEmailUserFactory.create(active=True) for i in range(2)]
-        BasicEmailUserFactory.create(extended_profile=True)
         BasicEmailUserFactory.create(group=True)
         BasicEmailUserFactory.create(group=True, active=True)
         BasicEmailUserFactory.create(use_custom_name=True)
         BasicEmailUserFactory.create(use_custom_name=True, active=True)
+
+        self.stdout.write('Creating Fellows')
+        fellows_profile_type = ProfileType.objects.get(value='fellow')
+        program_years = ProgramYear.objects.all()
+        program_types = ProgramType.objects.all()
+
+        for program_year in program_years:
+            for program_type in program_types:
+                for i in range(options['fellows_per_type']):
+                    ext_profile = ExtendedUserProfileFactory(
+                        profile_type=fellows_profile_type,
+                        program_year=program_year,
+                        program_type=program_type
+                    )
+                    BasicEmailUserFactory.create(
+                        active=True,
+                        profile=ext_profile
+                    )
 
         self.stdout.write('Creating Mozilla users')
         MozillaEmailUserFactory.create()


### PR DESCRIPTION
This PR adds some code to the `load_fake_data` command that will iterate over program types, and program years to generate a random set of fake Mozilla Fellows.

By default it will generate 3 fellows per program per year, but you can tweak that number with the `--fellowsCount` flag