### PR TITLE
Pass user context to serializers for bookmark verification

### DIFF
--- a/pulseapi/entries/serializers.py
+++ b/pulseapi/entries/serializers.py
@@ -66,9 +66,7 @@ class EntryBaseSerializer(serializers.ModelSerializer):
         Check whether the current user has bookmarked this
         Entry. Anonymous users always see False
         """
-        user = None
-        if 'request' in self.context and hasattr(self.context['request'], 'user'):
-            user = self.context['request'].user
+        user = self.context.get('user')
 
         if user and user.is_authenticated():
             # instance.bookmarked_by.all() is already prefetched and cached in the QuerySet

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -225,6 +225,11 @@ class EntryView(RetrieveAPIView):
 
         return EntrySerializerWithCreators
 
+    def get_serializer_context(self):
+        return {
+            'user': self.request.user
+        }
+
 
 class BookmarkedEntries(ListAPIView):
     pagination_class = EntriesPagination
@@ -248,6 +253,11 @@ class BookmarkedEntries(ListAPIView):
             return EntrySerializerWithV1Creators
 
         return EntrySerializerWithCreators
+
+    def get_serializer_context(self):
+        return {
+            'user': self.request.user
+        }
 
     # When people POST to this route, we want to do some
     # custom validation involving CSRF and nonce validation,
@@ -421,6 +431,11 @@ class EntriesListView(ListCreateAPIView):
             return EntrySerializerWithV1Creators
 
         return EntrySerializerWithCreators
+
+    def get_serializer_context(self):
+        return {
+            'user': self.request.user
+        }
 
     # When people POST to this route, we want to do some
     # custom validation involving CSRF and nonce validation,

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -96,6 +96,7 @@ class TestProfileView(PulseMemberTestCase):
         expected_entries = UserProfileEntriesSerializer(
             instance=profile,
             context={
+                'user': self.user,
                 'created': entry_type is 'created',
                 'published': entry_type is 'published',
                 'favorited': entry_type is 'favorited',
@@ -298,6 +299,7 @@ class TestProfileView(PulseMemberTestCase):
 
         profile_list = profile_serializer_class(
             UserProfile.objects.filter(profile_type=profile_type),
+            context={'user': self.user},
             many=True,
         ).data
 

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -43,6 +43,11 @@ class UserProfilePublicAPIView(RetrieveAPIView):
 
         return UserProfilePublicSerializer
 
+    def get_serializer_context(self):
+        return {
+            'user': self.request.user
+        }
+
 
 class UserProfilePublicSelfAPIView(UserProfilePublicAPIView):
     def get_object(self):
@@ -61,6 +66,11 @@ class UserProfileAPIView(RetrieveUpdateAPIView):
     def get_object(self):
         user = self.request.user
         return get_object_or_404(UserProfile, related_user=user)
+
+    def get_serializer_context(self):
+        return {
+            'user': self.request.user
+        }
 
     def put(self, request, *args, **kwargs):
         '''
@@ -92,8 +102,6 @@ class UserProfileAPIView(RetrieveUpdateAPIView):
 # We don't inherit from a generic API view class since we're customizing
 # the get functionality more than the generic would allow.
 class UserProfileEntriesAPIView(APIView):
-    authentication_classes = []
-
     def get(self, request, pk, **kwargs):
         """
         Return a list of entries associated with this profile
@@ -112,10 +120,11 @@ class UserProfileEntriesAPIView(APIView):
 
         return Response(
             UserProfileEntriesSerializer(instance=profile, context={
+                'user': request.user,
                 'created': 'created' in query,
                 'published': 'published' in query,
                 'favorited': 'favorited' in query,
-                'EntrySerializerClass': EntrySerializerClass
+                'EntrySerializerClass': EntrySerializerClass,
             }).data
         )
 
@@ -228,3 +237,8 @@ class UserProfileListAPIView(ListAPIView):
         if 'basic' in request.query_params:
             return UserProfileBasicSerializer
         return UserProfilePublicSerializer
+
+    def get_serializer_context(self):
+        return {
+            'user': self.request.user
+        }


### PR DESCRIPTION
Fix #358

To test:
1. Login to the pulse front-end. (Note your profile id).
2. Bookmark an entry on the front-end.
3. Make sure you're logged into the pulse api backend (see if you can access the admin).
4. Go to `/api/pulse/profiles/<id>/entries/?favorited=true` and make sure that the entry you bookmarked is there with `is_bookmarked: true`.