### PR TITLE
Remove repo from list (404) + don't add empty line in repo list

### DIFF
--- a/global_sprint_repo_list.txt
+++ b/global_sprint_repo_list.txt
@@ -52,7 +52,6 @@ publiccodenet/http
 publiccodenet/projects
 publiccodenet/jekyll-theme
 publiccodenet/smart-cities-public-code
-FahimaZulfath/Spread-Open-Healthy-Web
 SOHW/Blogs
 SOHW/sohw.github.io
 ricklupton/floweaver

--- a/pulseapi/utility/contributions_data.py
+++ b/pulseapi/utility/contributions_data.py
@@ -53,9 +53,7 @@ class GithubEvent(object):
 # Get the list of repos we need contribution data from
 def get_repo_list():
     with open(Path(settings.BASE_DIR + '/global_sprint_repo_list.txt')) as f:
-        repo_list = f.read().split('\n')
-
-    return repo_list
+        return [l.rstrip() for l in f]
 
 
 # Check if the data was updated in the last two hours. If not, alert.


### PR DESCRIPTION
- `FahimaZulfath/Spread-Open-Healthy-Web` is doing a 404 since May 20th, so I removed it from the list.
- An empty line at the end of the file is not considered as a repo to check anymore 😅 