### PR TITLE
Global Sprint - Catch missing rate limit header

### DIFF
--- a/pulseapi/utility/contributions_data.py
+++ b/pulseapi/utility/contributions_data.py
@@ -119,8 +119,11 @@ def create_events_csv(repos):
             for page in range(1, 11):
                 try:
                     r = session.get(f'https://api.github.com/repos/{repo}/events?page={page}&access_token={token}')
-                    if int(r.headers['X-RateLimit-Remaining']) == 0:
-                        raise RateLimitExceptionError
+                    try:
+                        if int(r.headers['X-RateLimit-Remaining']) == 0:
+                            raise RateLimitExceptionError
+                    except KeyError as e:
+                        print(f"Response from Github API for {repo} did not contain the X-RateLimit-Remaining header. Continuing execution as if it were present...")
                 except MaxRetryError as err:
                     print(f"Request made to Github API for {repo} failed. Error message: {err}")
                     repo_error.append(repo)

--- a/pulseapi/utility/contributions_data.py
+++ b/pulseapi/utility/contributions_data.py
@@ -123,7 +123,8 @@ def create_events_csv(repos):
                         if int(r.headers['X-RateLimit-Remaining']) == 0:
                             raise RateLimitExceptionError
                     except KeyError as e:
-                        print(f"Response from Github API for {repo} did not contain the X-RateLimit-Remaining header. Continuing execution as if it were present...")
+                        print(f"Response from Github API for {repo} did not contain the X-RateLimit-Remaining header. "
+                               "Continuing execution as if it were present...")
                 except MaxRetryError as err:
                     print(f"Request made to Github API for {repo} failed. Error message: {err}")
                     repo_error.append(repo)

--- a/pulseapi/utility/contributions_data.py
+++ b/pulseapi/utility/contributions_data.py
@@ -124,7 +124,7 @@ def create_events_csv(repos):
                             raise RateLimitExceptionError
                     except KeyError as e:
                         print(f"Response from Github API for {repo} did not contain the X-RateLimit-Remaining header. "
-                               "Continuing execution as if it were present...")
+                              "Continuing execution as if it were present...")
                 except MaxRetryError as err:
                     print(f"Request made to Github API for {repo} failed. Error message: {err}")
                     repo_error.append(repo)


### PR DESCRIPTION
In the logs I found that we're sometimes getting a keyerror when the rate limit header is missing from the github api response. This catches and ignores that.

Either one of you able to review?