### PR TITLE
Add catch-up task and fix setup task

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ Replies with an Atom feed consisting of (a subset of) only those entries that ar
 
 **If you're on Windows:** you will need to Create a super user by running `pipenv run python manage.py createsuperuser`
 
-`inv setup` takes care of installing the project's dependencies, copying environment variables, creating a superuser when possible and generating fake data. When it's done, do `inv runserver` to start your local server.
+`inv setup` takes care of installing the project's dependencies, copying environment variables, creating a superuser when possible and generating fake data. When it's done, follow the instructions. To start your local server, run `inv runserver`.
 
 You can get a full list of inv commands by running `inv -l`.
 
@@ -709,7 +709,8 @@ Available tasks:
 - `inv makemigrations`: Creates new migration(s) for apps
 - `inv migrate`: Updates database schema
 - `inv runserver`: Start a web server
-- `inv setup`: Prepare your dev environment after a fresh git clone.
+- `inv setup`: Automate project's configuration and dependencies installation
+- `inv catch-up`: Install dependencies and apply migrations
 - `inv test`: Run tests and linter
 
 For management commands not covered by an invoke tasks, use `inv manage [command]` (example: `inv manage load_fake_data`). You can pass flag and options to management commands using `inv manage [command] -o [positional argument] -f [optional argument]`. For example:

--- a/tasks.py
+++ b/tasks.py
@@ -67,35 +67,51 @@ def test(ctx):
 
 @task
 def setup(ctx):
-    """Prepare your dev environment after a fresh git clone"""
+    """Automate project's configuration and dependencies installation"""
     with ctx.cd(ROOT):
-        print("Copying default environment variables")
-        copy("sample.env", ".env")
-        print("Installing Python dependencies")
-        ctx.run("pipenv install --dev")
-        print("Applying database migrations")
-        ctx.run("inv migrate")
-        print("Creating fake data")
-        ctx.run("inv manage load_fake_data")
-        print("Creating 'client_secrets.json' file")
-        ctx.run("pipenv run python generate_client_secrets.py", **PLATFORM_ARG)
-        # Windows doesn't support pty, skipping createsuperuser step
-        if platform == 'win32':
-            print("Done!\n"
-                  "To finish your setup:\n"
-                  "1. Set up a Google client here: https://console.developers.google.com/apis/credentials.\n"
-                  "Then, open 'client_secrets.json' and edit 'client_id' and 'client_secret' with your Google "
-                  "client's values.\n"
-                  "2. Create a superuser by running 'pipenv run python manage.py createsuperuser'\n"
-                  "When it's done, start your dev server by running 'inv runserver'. You can get a full list of inv "
-                  "commands with 'inv -l'")
+        if os.path.isfile(".env"):
+            print("'.env' file found:\n"
+                  "- If you want to completely redo your dev setup, delete your '.env' file and your database. Then "
+                  "run 'inv setup' again.\n"
+                  "- If you want to catch up with the latest changes, like after a 'git pull', run 'inv catch-up' "
+                  "instead.")
         else:
-            print("Creating superuser")
-            ctx.run("pipenv run python manage.py createsuperuser", pty=True)
-            print("Done!\n"
-                  "To finish your setup, set up a Google client here: "
-                  "https://console.developers.google.com/apis/credentials.\n"
-                  "Then, open 'client_secrets.json' and edit 'client_id' and 'client_secret' with your Google "
-                  "client's values.\n"
-                  "When it's done, start your dev server by running 'inv runserver'. You can get a full list of inv "
-                  "commands with 'inv -l'")
+            print("Copying default environment variables")
+            copy("sample.env", ".env")
+            print("Installing Python dependencies")
+            ctx.run("pipenv install --dev --three")
+            print("Applying database migrations")
+            ctx.run("inv migrate")
+            print("Creating fake data")
+            ctx.run("inv manage load_fake_data")
+            print("Creating 'client_secrets.json' file")
+            ctx.run("pipenv run python generate_client_secrets.py", **PLATFORM_ARG)
+            # Windows doesn't support pty, skipping createsuperuser step
+            if platform == 'win32':
+                print("Done!\n"
+                      "To finish your setup:\n"
+                      "1. Set up a Google client here: https://console.developers.google.com/apis/credentials.\n"
+                      "Then, open 'client_secrets.json' and edit 'client_id' and 'client_secret' with your Google "
+                      "client's values.\n"
+                      "2. Create a superuser by running 'pipenv run python manage.py createsuperuser'\n"
+                      "When it's done, start your dev server by running 'inv runserver'. You can get a full list of "
+                      "inv commands with 'inv -l'")
+            else:
+                print("Creating superuser")
+                ctx.run("pipenv run python manage.py createsuperuser", pty=True)
+                print("Done!\n"
+                      "To finish your setup, set up a Google client here: "
+                      "https://console.developers.google.com/apis/credentials.\n"
+                      "Then, open 'client_secrets.json' and edit 'client_id' and 'client_secret' with your Google "
+                      "client's values.\n"
+                      "When it's done, start your dev server by running 'inv runserver'. You can get a full list of "
+                      "inv commands with 'inv -l'")
+
+
+@task()
+def catch_up(ctx):
+    """Install dependencies and apply migrations"""
+    print("Installing Python dependencies")
+    ctx.run("pipenv install --dev")
+    print("Applying database migrations")
+    ctx.run("inv migrate")


### PR DESCRIPTION
Ref mozilla/foundation.mozilla.org#1575

Running `inv setup` on an already configured project would silently replace your `.env` by the default one. It's now fixed: the script will stop if a `.env` is already there and proposes two solutions to the user.
I added a `inv catch-up` command that will only run `pipenv install` and apply migrations.

If this solution is okay, I will apply the same changes to the `tasks.py` of the foundation site.