### PR TITLE
Order profile entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,13 @@ __NOTE__: If none of the filters are specified, only the number of entries direc
 
 Based on the filter specified, the response payload will accordingly contain a `created`, `published`, and/or `favorited` property, each of whose value is a list of their corresponding entry objects.
 
+The order of the entries returned for each filter can be specified using the corresponding ordering query argument. The value of the query argument should be the entry field (prefixed with `-` for descending order) to use for ordering. The supported ordering arguments are:
+- `?created_ordering`: Specify the order of entries created by this profile.
+- `?published_ordering`: Specify the order of entries published by this profile.
+- `?favorited_ordering`: Specify the order of entries bookmarked/favorited by this profile.
+
+For example, `?created&created_ordering=-id` will return the entries created by the profile reverse ordered by the entry `id`.
+
 The schema of the entry objects is specified below:
 
 ```
@@ -701,7 +708,7 @@ The reason behind this is that our CORS withelist regex is messed up by [a bug i
 
 ### Using invoke
 
-Invoke is a task execution tool. Instead of running `pipenv run python manage.py runserver`, you can run `inv 
+Invoke is a task execution tool. Instead of running `pipenv run python manage.py runserver`, you can run `inv
 runserver`.
 
 Available tasks:

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -238,7 +238,8 @@ class UserProfileEntriesSerializer(serializers.Serializer):
             }
 
         entry_queryset = Entry.objects.prefetch_related(
-            'related_entry_creators__profile__related_user'
+            'related_entry_creators__profile__related_user',
+            'bookmarked_by__profile__related_user',
         )
 
         if include_created:

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -215,6 +215,18 @@ class UserProfileEntriesSerializer(serializers.Serializer):
     returning the number of entries (created, published, and favorited) associated
     with the profile.
     """
+    @staticmethod
+    def get_ordered_queryset(queryset, ordering_param=None, prefix=False):
+        if not ordering_param:
+            return queryset
+
+        if prefix:
+            if ordering_param[0] is '-':
+                ordering_param = '-' + prefix + ordering_param[1:]
+            else:
+                ordering_param = prefix + ordering_param
+
+        return queryset.order_by(ordering_param)
 
     def to_representation(self, instance):
         data = {}
@@ -223,6 +235,9 @@ class UserProfileEntriesSerializer(serializers.Serializer):
         include_created = context.get('created', False)
         include_published = context.get('published', False)
         include_favorited = context.get('favorited', False)
+        created_ordering = context.get('created_ordering', False)
+        published_ordering = context.get('published_ordering', False)
+        favorited_ordering = context.get('favorited_ordering', False)
         EntrySerializerClass = context.get('EntrySerializerClass', EntryWithCreatorsBaseSerializer)
 
         # If none of the filter options are provided, only return the count of
@@ -243,11 +258,15 @@ class UserProfileEntriesSerializer(serializers.Serializer):
         )
 
         if include_created:
-            entry_creators = (
-                EntryCreator.objects
-                .prefetch_related(Prefetch('entry', queryset=entry_queryset))
-                .filter(profile=instance)
-                .filter(entry__in=Entry.objects.public())
+            entry_creators = UserProfileEntriesSerializer.get_ordered_queryset(
+                queryset=(
+                    EntryCreator.objects
+                    .prefetch_related(Prefetch('entry', queryset=entry_queryset))
+                    .filter(profile=instance)
+                    .filter(entry__in=Entry.objects.public())
+                ),
+                ordering_param=created_ordering,
+                prefix='entry__',
             )
             data['created'] = [
                 EntrySerializerClass(
@@ -258,7 +277,14 @@ class UserProfileEntriesSerializer(serializers.Serializer):
             ]
 
         if include_published:
-            entries = entry_queryset.public().filter(published_by=instance.user) if instance.user else []
+            if instance.user:
+                entries = UserProfileEntriesSerializer.get_ordered_queryset(
+                    queryset=entry_queryset.public().filter(published_by=instance.user),
+                    ordering_param=published_ordering,
+                )
+            else:
+                entries = []
+
             data['published'] = EntrySerializerClass(
                 entries,
                 context={'user': user},
@@ -266,12 +292,17 @@ class UserProfileEntriesSerializer(serializers.Serializer):
             ).data
 
         if include_favorited:
-            user_bookmarks = UserBookmarks.objects.filter(profile=instance)
+            user_bookmarks = UserProfileEntriesSerializer.get_ordered_queryset(
+                queryset=(
+                    UserBookmarks.objects.filter(profile=instance)
+                    .filter(entry__in=Entry.objects.public())
+                    .prefetch_related(Prefetch('entry', queryset=entry_queryset))
+                ),
+                ordering_param=favorited_ordering,
+                prefix='entry__',
+            )
             data['favorited'] = [
-                EntrySerializerClass(bookmark.entry, context={'user': user}).data for bookmark in
-                user_bookmarks.prefetch_related(
-                    Prefetch('entry', queryset=entry_queryset)
-                ).filter(entry__in=Entry.objects.public())
+                EntrySerializerClass(bookmark.entry, context={'user': user}).data for bookmark in user_bookmarks
             ]
 
         return data

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -131,6 +131,9 @@ class UserProfileEntriesAPIView(APIView):
                 'created': 'created' in query,
                 'published': 'published' in query,
                 'favorited': 'favorited' in query,
+                'created_ordering': query.get('created_ordering'),
+                'published_ordering': query.get('published_ordering'),
+                'favorited_ordering': query.get('favorited_ordering'),
                 'EntrySerializerClass': EntrySerializerClass,
             }).data
         )


### PR DESCRIPTION
Fix #370 

This PR also fixes a regression in performance for getting profile entries where we were running over 55 SQL queries before because we weren't prefetching bookmarks.

To test:
1. Run migrations, and populate data (either from prod to test performance or using fake data)
2. Hit up `/api/pulse/v2/profiles/<id>/entries/?created&created_ordering=-created` and make sure that the entries returned are in reverse chronological order (you can rely on the `id` to verify that)
3. Repeat the above with `?published&published_ordering=-id` and `?favorited&favorited_ordering=title` (for this last one just make sure that the entries are ordered alphabetically by their title).