### PR TITLE
Fix bare excepts + cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 
 # command to run tests
 script:
-  - pipenv run flake8 pulseapi --config=./pulseapi/tox.ini --ignore=E722
+  - pipenv run flake8 pulseapi --config=./pulseapi/tox.ini
   - pipenv run python manage.py test
 
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ before_test:
   - "python -m pipenv run python manage.py migrate"
 
 test_script:
-  - "python -m pipenv run flake8 pulseapi --config=./pulseapi/tox.ini --ignore=E722"
+  - "python -m pipenv run flake8 pulseapi --config=./pulseapi/tox.ini"
   - "python -m pipenv run python manage.py test"
 
 cache:

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -49,18 +49,7 @@ class EntryQuerySet(models.query.QuerySet):
         """
         Return all entries that have been approved
         """
-        try:
-            # This has to happen in a try/catch, so that migrations
-            # don't break. Presumably this is due to the fact that
-            # during migrations, Entry can exist prior to ModerationState
-            # and so if its query set is checked, it'll crash out due
-            # to the absence of the associated ModerationState table.
-            approved = ModerationState.objects.get(name='Approved')
-            return self.filter(moderation_state=approved)
-
-        except:
-            print("could not make use of ModerationState!")
-            return self.all()
+        return self.filter(moderation_state__name='Approved')
 
     def with_related(self):
         """

--- a/pulseapi/entries/tests/test_staff_views.py
+++ b/pulseapi/entries/tests/test_staff_views.py
@@ -610,7 +610,7 @@ class TestEntryView(PulseStaffTestCase):
         self.assertEqual(postresponse.status_code, 204)
 
         # post with a non-existent id
-        invalidId = 'abc'
+        invalidId = '123'
 
         url = '/api/pulse/entries/bookmarks/?ids=' + invalidId
         payload = self.generatePostPayload()

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -3,6 +3,7 @@ Views to get entries
 """
 import base64
 import django_filters
+from django.core.exceptions import ObjectDoesNotExist
 
 from django.core.files.base import ContentFile
 from django.conf import settings
@@ -244,15 +245,13 @@ class BookmarkedEntries(ListAPIView):
             request.session['nonce'] = False
 
             user = request.user
-            ids = self.request.query_params.get('ids', None)
+            entryids = self.request.query_params.get('ids', None)
 
-            def bookmark_entry(id):
-                entry = None
-
+            def bookmark_entry(entryid):
                 # find the entry for this id
                 try:
-                    entry = Entry.objects.get(id=id)
-                except:
+                    entry = Entry.objects.get(id=entryid)
+                except ObjectDoesNotExist:
                     return
 
                 # find out if there is already a {user,entry,(timestamp)} triple
@@ -263,9 +262,9 @@ class BookmarkedEntries(ListAPIView):
                 if not bookmarks:
                     UserBookmarks.objects.create(entry=entry, profile=profile)
 
-            if ids is not None and user.is_authenticated():
-                for id in ids.split(','):
-                    bookmark_entry(id)
+            if entryids is not None and user.is_authenticated():
+                for entryid in entryids.split(','):
+                    bookmark_entry(entryid)
 
             return Response("Entries bookmarked.", status=status.HTTP_204_NO_CONTENT)
         else:

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -416,7 +416,7 @@ class EntriesListView(ListCreateAPIView):
 
         validation_result = post_validate(request)
 
-        if validation_result is True:
+        if validation_result:
             # invalidate the nonce, so this form cannot be
             # resubmitted with the current id
             request.session['nonce'] = False
@@ -439,7 +439,7 @@ class EntriesListView(ListCreateAPIView):
                     encdata = thumbnail['base64']
                     proxy = ContentFile(base64.b64decode(encdata), name=name)
                     request_data['thumbnail'] = proxy
-            except:
+            except KeyError:
                 pass
 
             # we also want to make sure that tags are properly split

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -10,7 +10,7 @@ from django.db.models import Q
 
 from rest_framework import filters, status
 from rest_framework.decorators import detail_route, api_view
-from rest_framework.generics import ListCreateAPIView, RetrieveAPIView, ListAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveAPIView, ListAPIView, get_object_or_404
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.parsers import JSONParser
@@ -37,26 +37,18 @@ def toggle_bookmark(request, entryid, **kwargs):
     user = request.user
 
     if user.is_authenticated():
-        entry = None
         profile = user.profile
 
-        # find the entry for this id
-        try:
-            entry = Entry.objects.get(id=entryid)
-        except Entry.DoesNotExist:
-            return Response("No such entry", status=status.HTTP_404_NOT_FOUND)
+        entry = get_object_or_404(Entry, id=entryid)
 
         # find out if there is already a {user,entry,(timestamp)} triple
         bookmarks = entry.bookmarked_by.filter(profile=profile)
-        exists = bookmarks.count() > 0
 
         # if there is a bookmark, remove it. Otherwise, make one.
-        if exists:
-            for bookmark in bookmarks:
-                bookmark.delete()
+        if bookmarks:
+            bookmarks.delete()
         else:
-            bookmark = UserBookmarks(entry=entry, profile=profile)
-            bookmark.save()
+            UserBookmarks.objects.create(entry=entry, profile=profile)
 
         return Response("Toggled bookmark.", status=status.HTTP_204_NO_CONTENT)
     return Response("Anonymous bookmarks cannot be saved.", status=status.HTTP_403_FORBIDDEN)
@@ -70,20 +62,14 @@ def toggle_featured(request, entryid, **kwargs):
     user = request.user
 
     if user.has_perm('entries.change_entry'):
-
-        entry = None
-        # find the entry for this id
-        try:
-            entry = Entry.objects.get(id=entryid)
-        except Entry.DoesNotExist:
-            return Response("No such entry", status=status.HTTP_404_NOT_FOUND)
+        entry = get_object_or_404(Entry, id=entryid)
 
         entry.featured = not entry.featured
         entry.save()
         return Response("Toggled featured status.",
                         status=status.HTTP_204_NO_CONTENT)
     return Response(
-        "You donot have permission to change entry featured status.",
+        "You don't have permission to change entry featured status.",
         status=status.HTTP_403_FORBIDDEN)
 
 
@@ -98,27 +84,13 @@ def toggle_moderation(request, entryid, stateid, **kwargs):
     user = request.user
 
     if user.has_perm('entries.change_entry') is True:
-        entry = None
-        moderation_state = None
-        status404 = status.HTTP_404_NOT_FOUND
-
-        # find the Entry in question
-        try:
-            entry = Entry.objects.get(id=entryid)
-        except Entry.DoesNotExist:
-            return Response("No such entry", status=status404)
-
-        # find the ModerationState in question
-        try:
-            moderation_state = ModerationState.objects.get(id=stateid)
-        except ModerationState.DoesNotExist:
-            return Response("No such moderation state", status=status404)
+        entry = get_object_or_404(Entry, id=entryid)
+        moderation_state = get_object_or_404(ModerationState, id=stateid)
 
         entry.moderation_state = moderation_state
         entry.save()
 
-        status204 = status.HTTP_204_NO_CONTENT
-        return Response("Updated moderation state.", status=status204)
+        return Response("Updated moderation state.", status=status.HTTP_204_NO_CONTENT)
 
     return Response(
         "You do not have permission to change entry moderation states.",
@@ -286,12 +258,10 @@ class BookmarkedEntries(ListAPIView):
                 # find out if there is already a {user,entry,(timestamp)} triple
                 profile = user.profile
                 bookmarks = entry.bookmarked_by.filter(profile=profile)
-                exists = bookmarks.count() > 0
 
                 # make a bookmark if there isn't one already
-                if exists is False:
-                    bookmark = UserBookmarks(entry=entry, profile=profile)
-                    bookmark.save()
+                if not bookmarks:
+                    UserBookmarks.objects.create(entry=entry, profile=profile)
 
             if ids is not None and user.is_authenticated():
                 for id in ids.split(','):

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -467,7 +467,7 @@ class EntriesListView(ListCreateAPIView):
                     name='Pending'
                 )
 
-                if (is_staff_address(user.email)):
+                if is_staff_address(user.email):
                     moderation_state = ModerationState.objects.get(
                         name='Approved'
                     )

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -364,8 +364,11 @@ class EntriesListView(ListCreateAPIView):
         ids = query_params.get('ids', None)
 
         if ids is not None:
-            ids = [int(x) for x in ids.split(',')]
-            queryset = queryset.filter(pk__in=ids)
+            try:
+                ids = [int(x) for x in ids.split(',')]
+                queryset = queryset.filter(pk__in=ids)
+            except ValueError:
+                pass
 
         creators = query_params.get('creators', None)
 

--- a/pulseapi/profiles/serializers.py
+++ b/pulseapi/profiles/serializers.py
@@ -19,7 +19,7 @@ from pulseapi.entries.serializers import (
 def remove_key(data, key):
     try:
         del data[key]
-    except:
+    except KeyError:
         pass
 
 

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -80,7 +80,7 @@ class UserProfileAPIView(RetrieveUpdateAPIView):
         }
 
     def put(self, request, *args, **kwargs):
-        '''
+        """
         If there is a thumbnail, and it was sent as part of an
         application/json payload, then we need to unpack a thumbnail
         object payload and convert it to a Python ContentFile payload
@@ -88,7 +88,7 @@ class UserProfileAPIView(RetrieveUpdateAPIView):
         we need to check using "if hasattr(request.data,'thumbnail'):"
         as we as "if request.data['thumbnail']" and these are pretty
         much mutually exclusive patterns. A try/pass make far more sense.
-        '''
+        """
 
         payload = request.data
 
@@ -100,7 +100,7 @@ class UserProfileAPIView(RetrieveUpdateAPIView):
                 encdata = thumbnail['base64']
                 proxy = ContentFile(base64.b64decode(encdata), name=name)
                 payload['thumbnail'] = proxy
-        except:
+        except KeyError:
             pass
 
         return super(UserProfileAPIView, self).put(request, *args, **kwargs)

--- a/pulseapi/utility/userpermissions.py
+++ b/pulseapi/utility/userpermissions.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import Group
+from django.core.exceptions import ObjectDoesNotExist
 
 
 def is_staff_address(email):
@@ -40,7 +41,7 @@ def assign_group_policy(user, name):
     try:
         group = Group.objects.get(name=name)
         group.user_set.add(user)
-    except:
+    except ObjectDoesNotExist:
         print("group", name, "not found")
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -60,7 +60,7 @@ def makemigrations(ctx):
 def test(ctx):
     """Run tests"""
     print("Running flake8")
-    ctx.run("pipenv run flake8 pulseapi  --ignore=E722", **PLATFORM_ARG)
+    ctx.run("pipenv run flake8 pulseapi", **PLATFORM_ARG)
     print("Running tests")
     manage(ctx, "test")
 


### PR DESCRIPTION
Closes #368

I also found an issue around the "ids" param for the entries list view: the `get_queryset` function from the `EntriesListView` [expects `int`](https://github.com/mozilla/network-pulse-api/blob/98d34a48eb5ec6b8d69dcf07f2f1139c97261e7b/pulseapi/entries/views.py#L366-L371) but if it gets `str`, it does 5xx ([example](https://api.mozillapulse.org/api/pulse/entries/?ids=abc)). Not sure it will ever happen, but now we're covered :D
