### PR TITLE
Add is_active flag to serialized entry creators

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Each `related_creator` object will have the following schema:
 {
   name: <string: name of the creator profile>
   profile_id: <integer: id of the creator profile>
+  is_active: <boolean: flag indicating whether this creator profile is attached to a user>
 }
 ```
 

--- a/pulseapi/creators/serializers.py
+++ b/pulseapi/creators/serializers.py
@@ -10,7 +10,8 @@ from pulseapi.entries.models import Entry
 def serialize_profile_as_creator(profile):
     return {
         'name': profile.name,
-        'profile_id': profile.id
+        'profile_id': profile.id,
+        'is_active': profile.is_active,
     }
 
 


### PR DESCRIPTION
Fix #389 

Since this change is additive, it doesn't need to be versioned.

To test:
1. Create an entry and for its creators, autocomplete some profiles and type in the rest (so they aren't existing profiles).
2. Hit up `/api/pulse/v2/profiles/<your profile id>/entries/?published` and check that the `related_creators` for your entry has the correct boolean for `is_active`.

either @Pomax or @alanmoo can review...whoever has the bandwidth to do so.