### PR TITLE
Filter entries by the presence of help types

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The schema for the payload returned is:
 - `?tag=<string>` - Filter entries by a specific tag
 - `?issue=<string>` - Filter entries by an issue area
 - `?help_type=<string>` - Filter entries by a specific help category
+- `?has_help_types=<True or False>` - Filter entries by whether they have help types or not. Note that `True` or `False` is case-sensitive.
 - `?featured=<true or false>` - Filter featured or non-featured entries
 - `?ordering=<string>` - Order entries by a certain property e.g. `?ordering=title`. Prepend the property with a hyphen to get entries in descending order, e.g. `?ordering=-title`
 - `?moderationstate=<string>` - Filter entries by its moderation state. This filter will only be applied if the API call was made by an authenticated user with moderation permissions

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -306,6 +306,9 @@ class EntriesListView(ListCreateAPIView):
     - `?tag=` - Allows filtering entries by a specific tag
     - `?issue=` - Allows filtering entries by a specific issue
     - `?help_type=` - Allows filtering entries by a specific help type
+    - `?has_help_types=<True or False>` - Filter entries by whether they have
+                                          help types or not. Note that `True`
+                                          or `False` is case-sensitive.
     - `?featured=True` (or False) - both capitalied. Boolean is set in admin UI
     - `?page=` - Page number, defaults to 1
     - `?page_size=` - Number of results on a page. Defaults to 48

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -167,6 +167,11 @@ class EntryCustomFilter(filters.FilterSet):
         name='help_types__name',
         lookup_expr='iexact',
     )
+    has_help_types = django_filters.BooleanFilter(
+        name='help_types',
+        lookup_expr='isnull',
+        exclude=True,
+    )
     featured = django_filters.BooleanFilter(
         name='featured'
     )

--- a/pulseapi/helptypes/factory.py
+++ b/pulseapi/helptypes/factory.py
@@ -1,0 +1,14 @@
+"""
+Create fake help types for local development, tests, and Heroku's review app.
+"""
+
+from factory import DjangoModelFactory, Faker
+
+from pulseapi.helptypes.models import HelpType
+
+
+class HelpTypeFactory(DjangoModelFactory):
+    name = Faker('job')
+
+    class Meta:
+        model = HelpType


### PR DESCRIPTION
Fix #392

To test (if needed although the automated test pretty much covers it):
1. Create an entry with a few help types and another without help types.
2. Hit up `/api/pulse/v2/entries/?has_help_types=True` and make sure the entry with help types is present. Do the same with `False` and make sure the entry without help types is present.
3. r+ my patch :)