### PR TITLE
profile categories endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,18 @@ If a user's profile has the `enable_extended_information` flag set to `True`, th
 }
 ```
 
+### `GET /api/pulse/profiles/categories`
+
+This retrieves an object containing exhaustive lists of the profile types, program types, and program years available to use when filtering profiles
+
+```
+{
+    profile_types: ["plain", "staff", "fellow", "board member", "grantee"],
+    program_types: ["tech policy fellowship", "mozfest speaker"],
+    program_years: ["2014", "2015", "2016", "2017", "2018"]
+}
+```
+
 ## Tags
 
 ### `GET /api/pulse/tags/` with optional `?format=json`

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -2,7 +2,6 @@ import json
 from urllib.parse import urlencode
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from collections import namedtuple
 
 from .models import UserProfile, ProfileType, ProgramType, ProgramYear
 

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -26,11 +26,6 @@ from pulseapi.profiles.serializers import (
 from pulseapi.profiles.factory import UserBookmarksFactory, ExtendedUserProfileFactory
 
 
-# Converts the JSON String to a named tuple - The name of the tuple (X) is unimportant
-def json_to_obj(data):
-    return json.loads(data, object_hook=lambda data: namedtuple('X', data.keys())(*data.values()))
-
-
 class TestProfileView(PulseMemberTestCase):
     def test_get_single_profile_data(self):
         """
@@ -443,25 +438,7 @@ class TestProfileView(PulseMemberTestCase):
     def test_profile_categories(self):
         profile_categories_url = reverse('categories_view')
         response = self.client.get(profile_categories_url)
-        categories = json_to_obj(str(response.content, 'utf-8'))
-        self.assertListEqual(categories.profile_types, [
-            'plain',
-            'staff',
-            'fellow',
-            'board member',
-            'grantee'
-        ])
-        self.assertListEqual(categories.program_types, [
-            'senior fellow',
-            'science fellow',
-            'open web fellow',
-            'tech policy fellow',
-            'media fellow'
-        ])
-        self.assertListEqual(categories.program_years, [
-            '2015',
-            '2016',
-            '2017',
-            '2018',
-            '2019'
-        ])
+        categories = json.loads(str(response.content, 'utf-8'))
+        self.assertListEqual(categories['profile_types'], list(ProfileType.objects.values_list('value', flat=True)))
+        self.assertListEqual(categories['program_types'], list(ProgramType.objects.values_list('value', flat=True)))
+        self.assertListEqual(categories['program_years'], list(ProgramYear.objects.values_list('value', flat=True)))

--- a/pulseapi/profiles/urls.py
+++ b/pulseapi/profiles/urls.py
@@ -6,6 +6,7 @@ from pulseapi.profiles.views import (
     UserProfilePublicAPIView,
     UserProfilePublicSelfAPIView,
     UserProfileEntriesAPIView,
+    UserProfileCategoriesView,
 )
 
 urlpatterns = [
@@ -23,6 +24,11 @@ urlpatterns = [
         r'^me/',
         UserProfilePublicSelfAPIView.as_view(),
         name='profile_self',
+    ),
+    url(
+        r'^categories/$',
+        UserProfileCategoriesView.as_view(),
+        name='categories_view',
     ),
     # note that there is also a /myprofile route
     # defined in the root urls.py which connects

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -260,7 +260,7 @@ class UserProfileListAPIView(ListAPIView):
 
 
 class UserProfileCategoriesView(APIView):
-    def get(self, *args, **kwargs):
+    def get(self, request, **kwargs):
         profile_types = list(ProfileType.objects.values_list('value', flat=True))
         program_types = list(ProgramType.objects.values_list('value', flat=True))
         program_years = list(ProgramYear.objects.values_list('value', flat=True))

--- a/pulseapi/profiles/views.py
+++ b/pulseapi/profiles/views.py
@@ -15,7 +15,12 @@ from rest_framework.generics import (
     ListAPIView,
 )
 
-from pulseapi.profiles.models import UserProfile
+from pulseapi.profiles.models import (
+    UserProfile,
+    ProfileType,
+    ProgramType,
+    ProgramYear
+)
 from pulseapi.profiles.serializers import (
     UserProfileSerializer,
     UserProfilePublicSerializer,
@@ -252,3 +257,16 @@ class UserProfileListAPIView(ListAPIView):
         return {
             'user': self.request.user
         }
+
+
+class UserProfileCategoriesView(APIView):
+    def get(self, *args, **kwargs):
+        profile_types = list(ProfileType.objects.values_list('value', flat=True))
+        program_types = list(ProgramType.objects.values_list('value', flat=True))
+        program_years = list(ProgramYear.objects.values_list('value', flat=True))
+
+        return Response({
+            'profile_types': profile_types,
+            'program_types': program_types,
+            'program_years': program_years
+        })

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -1,4 +1,17 @@
 """pulseapi URL Configuration
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/1.10/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+Including another URLconf
+    1. Import the include() function: from django.conf.urls import url, include
+    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf import settings
 from django.conf.urls import url, include

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -1,17 +1,4 @@
 """pulseapi URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf import settings
 from django.conf.urls import url, include


### PR DESCRIPTION
This PR creates an endpoint that lists all the possible profile and program types, as well as program years. Includes a test.

The endpoint resides at: `/api/pulse/profiles/categories`

Fixes #394