### PR TITLE
replace `is` with `==`

### DIFF
--- a/pulseapi/profiles/serializers/profile_entries.py
+++ b/pulseapi/profiles/serializers/profile_entries.py
@@ -32,7 +32,7 @@ class UserProfileEntriesSerializer(serializers.Serializer):
             return queryset
 
         if prefix:
-            if ordering_param[0] is '-':
+            if ordering_param[0] == '-':
                 ordering_param = '-' + prefix + ordering_param[1:]
             else:
                 ordering_param = prefix + ordering_param

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -75,9 +75,9 @@ class TestProfileView(PulseMemberTestCase):
         self.assertNotIn('created_entries', profile_json)
 
     def run_test_profile_entries(self, version, entry_type, order_by=None):
-        get_created_entries = entry_type is 'created'
-        get_published_entries = entry_type is 'published'
-        get_favorited_entries = entry_type is 'favorited'
+        get_created_entries = entry_type == 'created'
+        get_published_entries = entry_type == 'published'
+        get_favorited_entries = entry_type == 'favorited'
         entry_serializer_class = EntryWithCreatorsBaseSerializer
         if version == settings.API_VERSIONS['version_1']:
             entry_serializer_class = EntryWithV1CreatorsBaseSerializer


### PR DESCRIPTION
Fixes https://github.com/mozilla/network-pulse-api/issues/461 by replacing several instances of string literal comaprisons that were using `is` with comparison that uses `==`, instead. This should have no effect on the code itself, but will make flake8 quite a bit happier.