### PR TITLE
fix the fact that with the regex version, local CORS does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,7 +913,6 @@ Configure the following environment variables as needed in your `.env` file. All
  - `SECRET_KEY` *(recommended)* &mdash; A unique, unpredictable string that will be used for cryptographic signing. PLEASE GENERATE A NEW SECRET STRING FOR PRODUCTION ENVIRONMENTS. **Defaults to a set string of characters.**
  - `SSL_PROTECTION` *(recommended)* &mdash; A catch-all boolean that indicates whether SSL encryption, XSS filtering, content-type sniff protection, HSTS, and cookie security should be enabled. THIS SHOULD LIKELY BE SET TO `True` IN A PRODUCTION ENVIRONMENT. **Defaults to `False`.**
  - `ALLOWED_HOSTS` &mdash; A comma-separated list of host domains that this app can serve. This is meant to prevent HTTP Host header attacks. **Defaults to a list of `test.example.com`, `localhost`, `network-pulse-api-staging.herokuapp.com`, and `network-pulse-api-production.herokuapp.com`.**
- - `CORS_ORIGIN_REGEX_WHITELIST` *(recommended)* &mdash; A comma-separated list of python regular expressions matching domains that should be enabled for CORS. **Defaults to anything running on `localhost` or on `test.example.com`.**
  - `CORS_ORIGIN_WHITELIST` &mdash; A comma-separated list of domains that should be allowed to make CORS requests. **Defaults to an empty list.**
  - `CSRF_TRUSTED_ORIGINS` &mdash; A comma-separated list of trusted domains that can send POST, PUT, and DELETE requests to this API. **Defaults to a list of `localhost:3000`, `localhost:8000`, `localhost:8080` , `test.example.com:8000`, and `test.example.com:3000`.**
 

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -28,7 +28,6 @@ root = app - 1
 environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 env = environ.Env(
     AUTH_STAFF_EMAIL_DOMAINS=(list, []),
-    CORS_ORIGIN_REGEX_WHITELIST=(list, []),
     CORS_ORIGIN_WHITELIST=(list, []),
     CSRF_TRUSTED_ORIGINS=(list, []),
     AWS_SQS_REGION=(str, None),
@@ -310,8 +309,6 @@ CORS_ALLOW_CREDENTIALS = True
 
 # and we want origin whitelisting
 CORS_ORIGIN_WHITELIST = env('CORS_ORIGIN_WHITELIST')
-
-CORS_ORIGIN_REGEX_WHITELIST = env('CORS_ORIGIN_REGEX_WHITELIST')
 
 CSRF_TRUSTED_ORIGINS = env('CSRF_TRUSTED_ORIGINS')
 CSRF_COOKIE_HTTPONLY = env('CSRF_COOKIE_HTTPONLY', default=SSL_PROTECTION)

--- a/sample.env
+++ b/sample.env
@@ -3,8 +3,8 @@ PULSE_FRONTEND_HOSTNAME=localhost:3000
 SECRET_KEY=BetPHpGoUXUwjaAXm6ArIhV95xLdDZtu8QEGnNXY3eTknIkD
 
 # Security settings
-CORS_ORIGIN_REGEX_WHITELIST=http://localhost:\d+,http://test.example.com:\d+
-CSRF_TRUSTED_ORIGINS=localhost:3000,localhost:8000,localhost:8080,test.example.com:8000,test.example.com:3000
+CORS_ORIGIN_WHITELIST=localhost:3000,localhost:8000,localhost:8080,test.example.com:3000,test.example.com:8000,test.example.com:8080
+CSRF_TRUSTED_ORIGINS=localhost:3000,localhost:8000,localhost:8080,test.example.com:3000,test.example.com:8000,test.example.com:8080
 SSL_PROTECTION=False
 AUTH_STAFF_EMAIL_DOMAINS=mozillafoundation.org
 LOGIN_ALLOWED_REDIRECT_DOMAINS=test.example.com:3000


### PR DESCRIPTION
When running network-pulse-api master and networl-pulse master together locally, I cannot for the life of me get them to cooperate, generating a million and one CORS errors in my browser dev console every time the pulse client tries to XHR some data from the pulse API... 

So this seems to be the only way I can make it work: remove the regex matching and stick with fully specified domains and ports =(

**if** we land this, we'll need to update our heroku env. vars to make sure the CORS whitelist has the correct values.

Testing for this is easy, but does require first checking out master for both pulse and pulse-api, running both, and verifying that there are CORS errors when loading http://localhost:3000 as well as http://test.example.com:3000 (if you have a test.example.com <=> 127.0.0.1 binding set up in your host file).

And yes, I added all of you for review mostly because I just want to make sure we all agree that CORS errors _actually_ occur. If one person can't reproduce it, there might be deeper magic at play =S