### PR TITLE
Migrating Django-filter to 2.0+

### DIFF
--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -164,24 +164,24 @@ class EntryCustomFilter(filters.FilterSet):
     category.
     """
     tag = django_filters.CharFilter(
-        name='tags__name',
+        field_name='tags__name',
         lookup_expr='iexact',
     )
     issue = django_filters.CharFilter(
-        name='issues__name',
+        field_name='issues__name',
         lookup_expr='iexact',
     )
     help_type = django_filters.CharFilter(
-        name='help_types__name',
+        field_name='help_types__name',
         lookup_expr='iexact',
     )
     has_help_types = django_filters.BooleanFilter(
-        name='help_types',
+        field_name='help_types',
         lookup_expr='isnull',
         exclude=True,
     )
     featured = django_filters.BooleanFilter(
-        name='featured'
+        field_name='featured'
     )
 
     class Meta:
@@ -332,7 +332,7 @@ class EntriesListView(ListCreateAPIView):
         filters.SearchFilter,
         filters.OrderingFilter,
     )
-    filter_class = EntryCustomFilter
+    filterset_class = EntryCustomFilter
     search_fields = (
         'title',
         'description',

--- a/pulseapi/profiles/views/profiles.py
+++ b/pulseapi/profiles/views/profiles.py
@@ -123,15 +123,15 @@ class ProfileCustomFilter(filters.FilterSet):
         lookup_expr='in'
     )
     profile_type = django_filters.CharFilter(
-        name='profile_type__value',
+        field_name='profile_type__value',
         lookup_expr='iexact',
     )
     program_type = django_filters.CharFilter(
-        name='program_type__value',
+        field_name='program_type__value',
         lookup_expr='iexact',
     )
     program_year = django_filters.CharFilter(
-        name='program_year__value',
+        field_name='program_year__value',
         lookup_expr='iexact',
     )
     name = django_filters.CharFilter(method='filter_name')
@@ -232,7 +232,7 @@ class UserProfileListAPIView(ListAPIView):
     )
     pagination_class = ProfilesPagination
 
-    filter_class = ProfileCustomFilter
+    filterset_class = ProfileCustomFilter
 
     def get_queryset(self):
         request = self.request


### PR DESCRIPTION
Related PR #525 

**UPDATES**

- DRF `ViewSet.filter_class` => `filterset_class` ([source](https://django-filter.readthedocs.io/en/master/guide/migration.html#view-attributes-renamed-867))
- `Filter.name` => `Filter.field_name` ([source](https://django-filter.readthedocs.io/en/master/guide/migration.html#filter-name-renamed-to-filter-field-name-792))