### PR TITLE
Add tags and issues to RSS feed

### DIFF
--- a/pulseapi/utility/syndication.py
+++ b/pulseapi/utility/syndication.py
@@ -51,7 +51,7 @@ class RSSFeedFromPulse(Feed):
 
     def item_link(self, entry):
         return entry.frontend_entry_url()
-    
+
     def item_categories(self, entry):
         return list(entry.tags.values_list('name', flat=True)) + list(entry.issues.values_list('name', flat=True))
 

--- a/pulseapi/utility/syndication.py
+++ b/pulseapi/utility/syndication.py
@@ -51,6 +51,9 @@ class RSSFeedFromPulse(Feed):
 
     def item_link(self, entry):
         return entry.frontend_entry_url()
+    
+    def item_categories(self, entry):
+        return list(entry.tags.values_list('name', flat=True)) + list(entry.issues.values_list('name', flat=True))
 
 
 # RSS feed for latest entries


### PR DESCRIPTION
Adds tags and issues as the "category" for entries in the RSS feed. Needed for https://github.com/mozilla/network-pulse-api/issues/553 and MozFest slack.