### PR TITLE
Review app admin management command now posts on slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,11 @@ Configure the following environment variables as needed in your `.env` file. All
 
  - `PULSE_FRONTEND_HOSTNAME` &mdash; The hostname for the front-end used for Pulse. This is used for the RSS and Atom feed data. **Defaults to `localhost:3000`.**
 
+### Review Apps bot variables
+
+- `GITHUB_TOKEN` &mdash; Used to get the PR title.
+- `SLACK_WEBHOOK_RA` &mdash; Incoming webhook of the `HerokuReviewAppBot` Slack app.
+
  ### Miscellaneous variables
 
  - `HEROKU_APP_NAME` &mdash; A domain used to indicate if this app is running as a review app on Heroku. This is used to determine if social authentication is available or not (since it isn't for review apps). **Defaults to an empty string.**

--- a/README.md
+++ b/README.md
@@ -931,8 +931,9 @@ While for local development we provide a `sample.env` that you can use as defaul
 
 ### Review App
 
-Opening a PR will automatically create a Review App in the `network-pulse-api` pipeline. It's not possible to use OAuth but you can still access the admin with `test@mozillafoundation.org` as a user. To get the password, you need to go to the Heroku dashboard, click on the menu of your Review App and select `View initial app setup...`. The password is in the `Run scripts & scale dynos` log.
+Opening a PR will automatically create a Review App in the `network-pulse-api` pipeline. Since it's not possible to use OAuth, you will need to log using Django admin. A slack bot posts credentials and links to Review Apps in to the `mofo-pulse-api-review-app` channel.
 
+This only work for Mo-Fo staff: you will need to manually open a Review App on Heroku for PRs opened by external contributors.
 
 ## Debugging all the things
 

--- a/app.json
+++ b/app.json
@@ -33,7 +33,9 @@
     },
     "USE_S3": "True",
     "SSL_PROTECTION": "False",
-    "DEBUG": "True"
+    "DEBUG": "True",
+    "GITHUB_TOKEN": "True",
+    "SLACK_WEBHOOK_RA": "True"
   },
   "addons": [
     "heroku-postgresql:hobby-dev"

--- a/app.json
+++ b/app.json
@@ -31,11 +31,15 @@
     "CSRF_TRUSTED_ORIGINS": {
       "required": true
     },
+    "GITHUB_TOKEN": {
+      "required": true
+    },
+    "SLACK_WEBHOOK_RA": {
+      "required": true
+    },
     "USE_S3": "True",
     "SSL_PROTECTION": "False",
-    "DEBUG": "True",
-    "GITHUB_TOKEN": "True",
-    "SLACK_WEBHOOK_RA": "True"
+    "DEBUG": "True"
   },
   "addons": [
     "heroku-postgresql:hobby-dev"

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -38,6 +38,8 @@ env = environ.Env(
     SECRET_KEY=(str, ''),
     SSL_PROTECTION=(bool, False),
     USE_S3=(bool, False),
+    GITHUB_TOKEN=(str, ''),
+    SLACK_WEBHOOK_RA=(str, ''),
 )
 
 SSL_PROTECTION = env('SSL_PROTECTION')
@@ -403,3 +405,7 @@ LOGGING = {
 }
 DJANGO_LOG_LEVEL = env('DJANGO_LOG_LEVEL')
 logging.config.dictConfig(LOGGING)
+
+# Review app slack bot
+GITHUB_TOKEN = env('GITHUB_TOKEN')
+SLACK_WEBHOOK_RA = env('SLACK_WEBHOOK_RA')

--- a/pulseapi/utility/management/commands/review_app_admin.py
+++ b/pulseapi/utility/management/commands/review_app_admin.py
@@ -14,7 +14,7 @@ from pulseapi.users.models import EmailUser
 
 
 class Command(BaseCommand):
-    help = 'Create a superuser for use on Heroku review apps'
+    help = 'Create a superuser to use on Heroku review apps'
 
     def handle(self, *args, **options):
         try:

--- a/pulseapi/utility/management/commands/review_app_admin.py
+++ b/pulseapi/utility/management/commands/review_app_admin.py
@@ -92,4 +92,4 @@ class Command(BaseCommand):
 
             # Raise if post request was a 4xx or 5xx
             r.raise_for_status()
-            print('Done!')
+            print('Superuser created!')

--- a/pulseapi/utility/management/commands/review_app_admin.py
+++ b/pulseapi/utility/management/commands/review_app_admin.py
@@ -1,18 +1,95 @@
 """
-Management command called during Heroku Review App post-deployment phase: create an admin user and print its random
-password in the logs.
+Management command called during Heroku Review App post-deployment phase: create an admin user and
+post the credentials on a private channel on Slack.
 """
+import re
 
+import requests
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand
+from factory import Faker
 
 from pulseapi.users.models import EmailUser
 
 
 class Command(BaseCommand):
-    help = "Create a superuser to use on Heroku Review App"
+    help = 'Create a superuser for use on Heroku review apps'
 
     def handle(self, *args, **options):
-        password = EmailUser.objects.make_random_password()
-        admin = EmailUser.objects.create_superuser('test', 'test@mozillafoundation.org', password)
-        admin.save()
-        self.stdout.write('Admin user created. Password: {}'.format(password))
+        try:
+            EmailUser.objects.get(email='admin@mozillafoundation.org')
+            print('superuser already exists')
+        except ObjectDoesNotExist:
+            password = Faker(
+                'password',
+                length=16,
+                special_chars=True,
+                digits=True,
+                upper_case=True,
+                lower_case=True
+            ).generate({})
+            EmailUser.objects.create_superuser('admin', 'admin@mozillafoundation.org', password)
+
+            reviewapp_name = settings.HEROKU_APP_NAME
+            m = re.search(r'\d+', reviewapp_name)
+            pr_number = m.group()
+
+            # Get PR's title from Github
+            token = settings.GITHUB_TOKEN
+            org = 'mozilla'
+            repo = 'network-pulse-api'
+            r = requests.get(f'https://api.github.com/repos/{org}/{repo}/pulls/{pr_number}&access_token={token}')
+            try:
+                pr_title = ': ' + r.json()['title']
+            except KeyError:
+                pr_title = ''
+
+            if r.json()['labels']:
+                for l in r.json()['labels']:
+                    if l['name'] == 'dependencies':
+                        color = '#BA55D3'
+                        break
+                    else:
+                        color = '#7CD197'
+            else:
+                color = '#7CD197'
+
+            slack_payload = {
+                'attachments': [
+                    {
+                        'fallback': 'New review app deployed: It will be ready in a minute!\n'
+                                    f'PR {pr_number}{pr_title}\n'
+                                    f'Login: admin@mozillafoundation.org\n'
+                                    f'Password: {password}\n'
+                                    f'URL: https://{reviewapp_name}.herokuapp.com',
+                        'pretext':  'New review app deployed. It will be ready in a minute!',
+                        'title':    f'PR {pr_number}{pr_title}\n',
+                        'text':     'Login: admin@mozillafoundation.org\n'
+                                    f'Password: {password}\n',
+                        'color':    f'{color}',
+                        'actions': [
+                            {
+                                'type': 'button',
+                                'text': 'View review app',
+                                'url': f'https://{reviewapp_name}.herokuapp.com'
+                            },
+                            {
+                                'type': 'button',
+                                'text': 'View PR on Github',
+                                'url': f'https://github.com/mozilla/network-pulse-api/pull/{pr_number}'
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            slack_webhook = settings.SLACK_WEBHOOK_RA
+            r = requests.post(f'{slack_webhook}',
+                              json=slack_payload,
+                              headers={'Content-Type': 'application/json'}
+                              )
+
+            # Raise if post request was a 4xx or 5xx
+            r.raise_for_status()
+            print('Done!')


### PR DESCRIPTION
Finding credentials in Heroku logs is far from optimal. Following the work I did on the Foundation site a while ago, I'm making the `review_app_admin` management command post a message on a private slack channel instead.

Related issue: MozillaFoundation/mofo-devops#716