### PR TITLE
Pre uplift test cases

### DIFF
--- a/pulseapi/entries/tests/test_member_views.py
+++ b/pulseapi/entries/tests/test_member_views.py
@@ -103,3 +103,16 @@ class TestMemberEntryView(PulseMemberTestCase):
 
         for creator, entry_creator in zip(related_creators, entry_creators):
             self.assertEqual(entry_creator.profile.custom_name, creator['name'])
+
+    def test_entry_api(self):
+        """
+        ...GENERATE ENTRIES WITH TAGS HERE...
+        """
+        response = self.client.get('/api/pulse/entries/?format=json')
+        self.assertEqual(response.status_code, 200)
+
+        response_data = json.loads(str(response.content, 'utf-8'))
+        print(response_data)
+
+        count = response_data['count']
+        self.assertEqual(count, 120)


### PR DESCRIPTION
This adds two test cases for making sure that we have something in place that can be used or even expanded when redoing (again, x2) the DRF uplift.

See https://github.com/mozilla/network-pulse-api/issues/544#issuecomment-565247923 for what we're dealing with =x