### PR TITLE
Use Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ venv
 
 #Editor
 /.vscode/
+/.idea/
 
 # Static files from python manage.py collectstatic
 /static/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 cache: pip
 
 python:
-  - "3.6"
+  - "3.7"
 
 services: postgresql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 cache: pip
 
 python:
-  - "3.7"
+  - "3.7.6"
 
 services: postgresql
 

--- a/Pipfile
+++ b/Pipfile
@@ -31,4 +31,4 @@ docutils = "*"
 flake8 = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "34147e0729ad2829cbc9ad2daa7e117a56473cdccae263fc60ec81e13bf27fae"
+            "sha256": "9d44ba4be1df7e778233d730b8a9b5c0aae2c3c73ab83b3f52938394bce7afe4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -11,7 +11,7 @@
             {
                 "name": "pypi",
                 "url": "https://pypi.python.org/simple",
-                "verify_ssl": false
+                "verify_ssl": true
             }
         ]
     },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,35 +1,35 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "930d48a49674555530a0e68d4dacf521bcb3bbc108e8400ac912184262159a50"
+            "sha256": "34147e0729ad2829cbc9ad2daa7e117a56473cdccae263fc60ec81e13bf27fae"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {
                 "name": "pypi",
                 "url": "https://pypi.python.org/simple",
-                "verify_ssl": true
+                "verify_ssl": false
             }
         ]
     },
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:25e6af364243673bacfe4bd422582f4a891e02ae433e266b03de6a6bfdd63d51",
-                "sha256:4ba878e6ea38d3821b571e29018e00f8a9ddab2678dd59433b1ecda331cf9aa6"
+                "sha256:0b9dc594e16a96ed7c6f37e1563ab3f113f130b3cc79efe8eea43097bf87fccb",
+                "sha256:e48ff93a3b6424c65675e1cbe08f7f3245b0128d1c27115cdcf51d432e9767d6"
             ],
             "index": "pypi",
-            "version": "==1.11.11"
+            "version": "==1.11.15"
         },
         "botocore": {
             "hashes": [
-                "sha256:5ad6f4b80f3151fc5aa940f89fb6bf2db3064bf8d3f8919f5b60f5c741054ba5",
-                "sha256:ac783a87bd90be8a4d08101bfc0d29a4b35fe0ced387f5c8bc91d01cdaa7a168"
+                "sha256:2538065f9f5023eae3607e78fc5d8c595c9173ec02bc92410652078617c44ac1",
+                "sha256:554231b1690c8521e05a41e50184e43d62941fdf9351e658aea894649b879985"
             ],
-            "version": "==1.14.11"
+            "version": "==1.14.15"
         },
         "cachetools": {
             "hashes": [
@@ -353,10 +353,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:2525bae2a530195576da53671bae8ca8c55ee8e33bc2225a65e804476611ea5a",
-                "sha256:4924e10451cc37901945806423d16c2c2040a6530645a614ed87e995ccec764c"
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
             ],
-            "version": "==0.3.2"
+            "version": "==0.3.3"
         },
         "six": {
             "hashes": [
@@ -391,6 +391,7 @@
                 "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
                 "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==1.25.8"
         },
         "whitenoise": {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ environment:
     AUTH_STAFF_EMAIL_DOMAINS: mozillafoundation.org
 
     matrix:
-      - PYTHON: "C:\\Python36"
-        PYTHON_VERSION: "3.6.x"
+      - PYTHON: "C:\\Python37"
+        PYTHON_VERSION: "3.7.x"
         PYTHON_ARCH: "64"
 
 init:

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.9
+python-3.7.6


### PR DESCRIPTION
Update pipfile, travis, appveyor, and Heroku to use Python 3.7

Fixes #490 