### PR TITLE
Pass github token in headers and not as a query param

### DIFF
--- a/pulseapi/utility/management/commands/review_app_admin.py
+++ b/pulseapi/utility/management/commands/review_app_admin.py
@@ -41,7 +41,9 @@ class Command(BaseCommand):
                 token = settings.GITHUB_TOKEN
                 org = 'mozilla'
                 repo = 'network-pulse-api'
-                r = requests.get(f'https://api.github.com/repos/{org}/{repo}/pulls/{pr_number}&access_token={token}')
+                headers = {'Authorization': f'token {token}'}
+                r = requests.get(f'https://api.github.com/repos/{org}/{repo}/pulls/{pr_number}', headers=headers)
+                r.raise_for_status()
                 try:
                     pr_title = ': ' + r.json()['title']
                 except KeyError:


### PR DESCRIPTION
Using token in query params are not deprecated.

Related PRs/issues mozillafoundation/mofo-devops-private#297