### PR TITLE
Add size limit in admin

### DIFF
--- a/pulseapi/entries/forms.py
+++ b/pulseapi/entries/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from ajax_select.fields import AutoCompleteSelectMultipleField
 
 from pulseapi.creators.models import EntryCreator
+from pulseapi.utility.image_validation import enforce_image_size_limit
 
 
 class EntryAdminForm(forms.ModelForm):
@@ -42,8 +43,4 @@ class EntryAdminForm(forms.ModelForm):
 
     def clean_thumbnail(self):
         data = self.cleaned_data["thumbnail"]
-        if not data:
-            return data
-        if data.size > 512*1024:
-            raise forms.ValidationError("Image size must be less than 500KB")
-        return data
+        return enforce_image_size_limit(data)

--- a/pulseapi/entries/forms.py
+++ b/pulseapi/entries/forms.py
@@ -39,3 +39,11 @@ class EntryAdminForm(forms.ModelForm):
         for creator_profile_id in creator_profile_id_list:
             profile_id = int(creator_profile_id)
             EntryCreator.objects.create(entry=entry, profile_id=profile_id)
+
+    def clean_thumbnail(self):
+        data = self.cleaned_data["thumbnail"]
+        if not data:
+            return data
+        if data.size > 512*1024:
+            raise forms.ValidationError("Image size must be less than 500KB")
+        return data

--- a/pulseapi/profiles/admin.py
+++ b/pulseapi/profiles/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.utils.html import format_html
 
+from pulseapi.profiles.forms import ProfileAdminForm
 from pulseapi.utility.get_admin_url import get_admin_url
 from .models import (
     ProfileType,
@@ -15,6 +16,9 @@ class UserProfileAdmin(admin.ModelAdmin):
     """
     Show the profile-associated user.
     """
+
+    form = ProfileAdminForm
+
     fields = (
         'created_at',
         'is_active',

--- a/pulseapi/profiles/forms.py
+++ b/pulseapi/profiles/forms.py
@@ -1,12 +1,10 @@
 from django import forms
 
+from pulseapi.utility.image_validation import enforce_image_size_limit
+
 
 class ProfileAdminForm(forms.ModelForm):
 
     def clean_thumbnail(self):
         data = self.cleaned_data["thumbnail"]
-        if not data:
-            return data
-        if data.size > 512*1024:
-            raise forms.ValidationError("Image size must be less than 500KB")
-        return data
+        return enforce_image_size_limit(data)

--- a/pulseapi/profiles/forms.py
+++ b/pulseapi/profiles/forms.py
@@ -1,0 +1,12 @@
+from django import forms
+
+
+class ProfileAdminForm(forms.ModelForm):
+
+    def clean_thumbnail(self):
+        data = self.cleaned_data["thumbnail"]
+        if not data:
+            return data
+        if data.size > 512*1024:
+            raise forms.ValidationError("Image size must be less than 500KB")
+        return data

--- a/pulseapi/utility/image_validation.py
+++ b/pulseapi/utility/image_validation.py
@@ -1,0 +1,7 @@
+from django import forms
+
+
+def enforce_image_size_limit(data):
+    if data and data.size > 512 * 1024:
+        raise forms.ValidationError("Image size must be less than 500KB")
+    return data


### PR DESCRIPTION
As I continue to work on optimizing the foundation site, I was surprised to see that images coming from pulse are well above 1MB.
For example, [the homepage](https://foundation.mozilla.org/en/) is 6MB, 4MB is images, 3.5MB **just** for pulse images.
Want something even scarier: https://www.mozillapulse.org/profile/82 is 61MB( image: 58MB), https://www.mozillapulse.org/latest is 14MB (images: 12MB)

Why 500kb? Because I was looking at the foundation site homepage and all the other images are below it and are still decent.

I'm adding this in admin to make sure that people login there to add entries won't be able to sneak something big again.

Similar PR is coming for pulse front.