### PR TITLE
optimize sql queries for profile admin

### DIFF
--- a/pulseapi/profiles/admin.py
+++ b/pulseapi/profiles/admin.py
@@ -48,7 +48,7 @@ class UserProfileAdmin(admin.ModelAdmin):
         'bookmark_count',
     )
 
-    list_select_related = ("profile_type", "program_year", "program_type", "related_user")
+    list_select_related = ('profile_type', 'program_year', 'program_type', 'related_user')
 
     list_display = (
         'name',

--- a/pulseapi/profiles/admin.py
+++ b/pulseapi/profiles/admin.py
@@ -48,6 +48,8 @@ class UserProfileAdmin(admin.ModelAdmin):
         'bookmark_count',
     )
 
+    list_select_related = ("profile_type", "program_year", "program_type", "related_user")
+
     list_display = (
         'name',
         'profile_type',


### PR DESCRIPTION
Use [`list_selected_related`](https://docs.djangoproject.com/en/3.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_select_related) to optimise our sql queries in profile admin.

It's reducing queries from 393 to 7.