### PR TITLE
switched to user_set.set() rather than user_set=...

### DIFF
--- a/pulseapi/users/admin_group_editing.py
+++ b/pulseapi/users/admin_group_editing.py
@@ -38,7 +38,7 @@ class GroupAdminForm(forms.ModelForm):
             self.fields['users'].initial = self.instance.user_set.all()
 
     def save_m2m(self):
-        self.instance.user_set = self.cleaned_data['users']
+        self.instance.user_set.set(self.cleaned_data['users'])
 
     def save(self, *args, **kwargs):
         return super(GroupAdminForm, self).save()


### PR DESCRIPTION
Closes https://github.com/mozilla/network-pulse-api/issues/715

At some point, Django added in protection against directly setting a many-to-many relation using `= ...`, instead requiring the user of `.set(...)` so that it can do whatever administrative overhead is required when updating those kinds of relations.

In the currently deployed version, we have `... = ...` for updating users (both actual user account and assigning accounts to user groups) so when trying to administer users, the server crashes when you try to save (yay!)

With this fix, that no longer happens.

STR:
- check out master
- `inv setup` or `inv new-db` depending on whether you need full setup or not
- `inv manage load_fake_data`
- `inv runserver`
- open http://localhost:8000/admin (log in as `admin@mozillafoundation.org` with password `admin`)

then

1. go to http://localhost:8000/admin/users/emailuser, click the first user's name, and then try to change their "staff" checkbox, and save. This will cause a crash.
2. go to http://localhost:8000/admin/auth/group/3/change/ and under "users" try to add someone from the left column into the right column by selecting them and clicking the (->) icon, then save. This will cause a crash.

Repeating these same steps with this branch will not cause any server crashing and will show the changes made as having been made.