### PR TITLE
Add recaptcha to the API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,59 +870,62 @@ Configure the following environment variables as needed in your `.env` file. All
 
 ### Authentication variables
 
- - `LOGIN_ALLOWED_REDIRECT_DOMAINS` &mdash; A comma-separated list of domains that are allowed to be redirected to after logging in a user. **Defaults to  `test.example.com:3000`.**
- - `AUTH_STAFF_EMAIL_DOMAINS` &mdash; A comma-separated list of email domains that should be considered "safe" to make as "staff" in Django. **Defaults to `mozillafoundation.org`.**
- - `AUTH_REQUIRE_EMAIL_VERIFICATION` &mdash; A boolean indicating whether a user needs to verify their email attached to a social account (e.g. Github) before being able to login. **Defaults to `False`.**
- - `AUTH_EMAIL_REDIRECT_URL` &mdash; The url to redirect to after a user verifies their email to login successfully. **Defaults to `/`.**
- - `PULSE_CONTACT_URL` &mdash; A contact url for users to file questions or problems when authenticating. **Defaults to an empty string.**
+- `ALLOW_SIGNUP` &mdash; Determines whether signing up for a new account is permitted. **Defaults to `True`.**
+- `LOGIN_ALLOWED_REDIRECT_DOMAINS` &mdash; A comma-separated list of domains that are allowed to be redirected to after logging in a user. **Defaults to  `test.example.com:3000`.**
+- `AUTH_STAFF_EMAIL_DOMAINS` &mdash; A comma-separated list of email domains that should be considered "safe" to make as "staff" in Django. **Defaults to `mozillafoundation.org`.**
+- `AUTH_REQUIRE_EMAIL_VERIFICATION` &mdash; A boolean indicating whether a user needs to verify their email attached to a social account (e.g. Github) before being able to login. **Defaults to `False`.**
+- `AUTH_EMAIL_REDIRECT_URL` &mdash; The url to redirect to after a user verifies their email to login successfully. **Defaults to `/`.**
+- `PULSE_CONTACT_URL` &mdash; A contact url for users to file questions or problems when authenticating. **Defaults to an empty string.**
+- `USE_RECAPTCHA` &mdash; Determines whether the login route is locked behind Google reCAPTCHA or not. **Defaults to `True`**.
+- `RECAPTCHA_SECRET` &mdash; The Google reCAPTCHA secret value. **Defaults to an empty string.**
 
- ### Email variables
+### Email variables
 
- - `USE_CONSOLE_EMAIL` &mdash; A boolean to indicate whether the terminal should be used to display emails sent from Django, instead of an email backend. Useful for local development. **Defaults to `True`.**
- - `EMAIL_VERIFICATION_FROM` &mdash; The email address used in the "From:" section of emails sent by Django. **Defaults to `webmaster@localhost`.**
+- `USE_CONSOLE_EMAIL` &mdash; A boolean to indicate whether the terminal should be used to display emails sent from Django, instead of an email backend. Useful for local development. **Defaults to `True`.**
+- `EMAIL_VERIFICATION_FROM` &mdash; The email address used in the "From:" section of emails sent by Django. **Defaults to `webmaster@localhost`.**
 
- These variables are only used (and are required) if `USE_CONSOLE_EMAIL` is set to `False`.
+These variables are only used (and are required) if `USE_CONSOLE_EMAIL` is set to `False`.
 
- - `MAILGUN_SMTP_SERVER` &mdash; The url for the Mailgun SMTP server that will be used to send emails.
- - `MAILGUN_SMTP_PORT` &mdash; The port (as a number) to connect to the Mailgun server.
- - `MAILGUN_SMTP_LOGIN` &mdash; The login user credential to use to authenticate with the Mailgun server.
- - `MAILGUN_SMTP_PASSWORD` &mdash; The password to authenticate with the Mailgun server.
+- `MAILGUN_SMTP_SERVER` &mdash; The url for the Mailgun SMTP server that will be used to send emails.
+- `MAILGUN_SMTP_PORT` &mdash; The port (as a number) to connect to the Mailgun server.
+- `MAILGUN_SMTP_LOGIN` &mdash; The login user credential to use to authenticate with the Mailgun server.
+- `MAILGUN_SMTP_PASSWORD` &mdash; The password to authenticate with the Mailgun server.
 
- ### Data storage variables
+### Data storage variables
 
- - `DATABASE_URL` &mdash; The url to connect to the database. **Defaults to `False` which forces Django to create a local SQLite database file.**
- - `USE_S3` &mdash; A boolean to indicate whether to store user generated assets (like images) on Amazon S3. **Defaults to `False`.**
+- `DATABASE_URL` &mdash; The url to connect to the database. **Defaults to `False` which forces Django to create a local SQLite database file.**
+- `USE_S3` &mdash; A boolean to indicate whether to store user generated assets (like images) on Amazon S3. **Defaults to `False`.**
 
- These variables are only used (and are required) if `USE_S3` is set to `True`.
+These variables are only used (and are required) if `USE_S3` is set to `True`.
 
- - `AWS_ACCESS_KEY_ID` &mdash; Amazon user Access Key for authentication.
- - `AWS_SECRET_ACCESS_KEY` &mdash; Amazon user Secret Key for authentication.
- - `AWS_STORAGE_BUCKET_NAME` &mdash; S3 bucket name where the assets will be stored.
- - `AWS_STORAGE_ROOT` &mdash; S3 root path in the bucket where assets will be stored.
- - `AWS_S3_CUSTOM_DOMAIN` &mdash; A custom domain (for e.g. Amazon CloudFront) used to access assets in the S3 bucket.
+- `AWS_ACCESS_KEY_ID` &mdash; Amazon user Access Key for authentication.
+- `AWS_SECRET_ACCESS_KEY` &mdash; Amazon user Secret Key for authentication.
+- `AWS_STORAGE_BUCKET_NAME` &mdash; S3 bucket name where the assets will be stored.
+- `AWS_STORAGE_ROOT` &mdash; S3 root path in the bucket where assets will be stored.
+- `AWS_S3_CUSTOM_DOMAIN` &mdash; A custom domain (for e.g. Amazon CloudFront) used to access assets in the S3 bucket.
 
- ### Security variables
+### Security variables
 
- - `DEBUG` *(recommended)* &mdash; A boolean that indicates whether Django should run in debug mode. DO NOT SET THIS TO `True` IN PRODUCTION ENVIRONMENTS SINCE YOU RISK EXPOSING PRIVATE DATA SUCH AS CREDENTIALS. **Defaults to `True`.**
- - `SECRET_KEY` *(recommended)* &mdash; A unique, unpredictable string that will be used for cryptographic signing. PLEASE GENERATE A NEW SECRET STRING FOR PRODUCTION ENVIRONMENTS. **Defaults to a set string of characters.**
- - `SSL_PROTECTION` *(recommended)* &mdash; A catch-all boolean that indicates whether SSL encryption, XSS filtering, content-type sniff protection, HSTS, and cookie security should be enabled. THIS SHOULD LIKELY BE SET TO `True` IN A PRODUCTION ENVIRONMENT. **Defaults to `False`.**
- - `ALLOWED_HOSTS` &mdash; A comma-separated list of host domains that this app can serve. This is meant to prevent HTTP Host header attacks. **Defaults to a list of `test.example.com`, `localhost`, `network-pulse-api-staging.herokuapp.com`, and `network-pulse-api-production.herokuapp.com`.**
- - `CORS_ORIGIN_REGEX_WHITELIST` *(recommended)* &mdash; A comma-separated list of python regular expressions matching domains that should be enabled for CORS. **Defaults to anything running on `localhost` or on `test.example.com`.**
- - `CORS_ORIGIN_WHITELIST` &mdash; A comma-separated list of domains that should be allowed to make CORS requests. **Defaults to an empty list.**
- - `CSRF_TRUSTED_ORIGINS` &mdash; A comma-separated list of trusted domains that can send POST, PUT, and DELETE requests to this API. **Defaults to a list of `localhost:3000`, `localhost:8000`, `localhost:8080` , `test.example.com:8000`, and `test.example.com:3000`.**
+- `DEBUG` *(recommended)* &mdash; A boolean that indicates whether Django should run in debug mode. DO NOT SET THIS TO `True` IN PRODUCTION ENVIRONMENTS SINCE YOU RISK EXPOSING PRIVATE DATA SUCH AS CREDENTIALS. **Defaults to `True`.**
+- `SECRET_KEY` *(recommended)* &mdash; A unique, unpredictable string that will be used for cryptographic signing. PLEASE GENERATE A NEW SECRET STRING FOR PRODUCTION ENVIRONMENTS. **Defaults to a set string of characters.**
+- `SSL_PROTECTION` *(recommended)* &mdash; A catch-all boolean that indicates whether SSL encryption, XSS filtering, content-type sniff protection, HSTS, and cookie security should be enabled. THIS SHOULD LIKELY BE SET TO `True` IN A PRODUCTION ENVIRONMENT. **Defaults to `False`.**
+- `ALLOWED_HOSTS` &mdash; A comma-separated list of host domains that this app can serve. This is meant to prevent HTTP Host header attacks. **Defaults to a list of `test.example.com`, `localhost`, `network-pulse-api-staging.herokuapp.com`, and `network-pulse-api-production.herokuapp.com`.**
+- `CORS_ORIGIN_REGEX_WHITELIST` *(recommended)* &mdash; A comma-separated list of python regular expressions matching domains that should be enabled for CORS. **Defaults to anything running on `localhost` or on `test.example.com`.**
+- `CORS_ORIGIN_WHITELIST` &mdash; A comma-separated list of domains that should be allowed to make CORS requests. **Defaults to an empty list.**
+- `CSRF_TRUSTED_ORIGINS` &mdash; A comma-separated list of trusted domains that can send POST, PUT, and DELETE requests to this API. **Defaults to a list of `localhost:3000`, `localhost:8000`, `localhost:8080` , `test.example.com:8000`, and `test.example.com:3000`.**
 
- ### Front-end variables
+### Front-end variables
 
- - `PULSE_FRONTEND_HOSTNAME` &mdash; The hostname for the front-end used for Pulse. This is used for the RSS and Atom feed data. **Defaults to `localhost:3000`.**
+- `PULSE_FRONTEND_HOSTNAME` &mdash; The hostname for the front-end used for Pulse. This is used for the RSS and Atom feed data. **Defaults to `localhost:3000`.**
 
 ### Review Apps bot variables
 
 - `GITHUB_TOKEN` &mdash; Used to get the PR title.
 - `SLACK_WEBHOOK_RA` &mdash; Incoming webhook of the `HerokuReviewAppBot` Slack app.
 
- ### Miscellaneous variables
+### Miscellaneous variables
 
- - `HEROKU_APP_NAME` &mdash; A domain used to indicate if this app is running as a review app on Heroku. This is used to determine if social authentication is available or not (since it isn't for review apps). **Defaults to an empty string.**
+- `HEROKU_APP_NAME` &mdash; A domain used to indicate if this app is running as a review app on Heroku. This is used to determine if social authentication is available or not (since it isn't for review apps). **Defaults to an empty string.**
 
 ## Deploying to Heroku
 

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -32,19 +32,26 @@ env = environ.Env(
     CORS_ORIGIN_REGEX_WHITELIST=(list, []),
     CORS_ORIGIN_WHITELIST=(list, []),
     CSRF_TRUSTED_ORIGINS=(list, []),
+    DATABASE_URL=(str, None),
     DEBUG=(bool, False),
     DJANGO_LOG_LEVEL=(str, 'INFO'),
-    DATABASE_URL=(str, None),
-    HEROKU_APP_NAME=(str, ''),
-    HEROKU_PR_NUMBER=(str, ''),
-    HEROKU_BRANCH=(str, ''),
-    PULSE_FRONTEND_HOSTNAME=(str, ''),
-    SECRET_KEY=(str, ''),
-    SSL_PROTECTION=(bool, False),
-    USE_S3=(bool, False),
     GITHUB_TOKEN=(str, ''),
+    HEROKU_APP_NAME=(str, ''),
+    HEROKU_BRANCH=(str, ''),
+    HEROKU_PR_NUMBER=(str, ''),
+    PULSE_FRONTEND_HOSTNAME=(str, ''),
+    RECAPTCHA_KEY=(str,''),
+    RECAPTCHA_SECRET=(str, ''),
+    SECRET_KEY=(str, ''),
     SLACK_WEBHOOK_RA=(str, ''),
+    SSL_PROTECTION=(bool, False),
+    USE_RECAPTCHA=(bool, False),
+    USE_S3=(bool, False),
 )
+
+USE_RECAPTCHA = env('USE_RECAPTCHA')
+RECAPTCHA_KEY = env('RECAPTCHA_KEY')
+RECAPTCHA_SECRET = env('RECAPTCHA_SECRET')
 
 SSL_PROTECTION = env('SSL_PROTECTION')
 

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -40,7 +40,6 @@ env = environ.Env(
     HEROKU_BRANCH=(str, ''),
     HEROKU_PR_NUMBER=(str, ''),
     PULSE_FRONTEND_HOSTNAME=(str, ''),
-    RECAPTCHA_KEY=(str,''),
     RECAPTCHA_SECRET=(str, ''),
     SECRET_KEY=(str, ''),
     SLACK_WEBHOOK_RA=(str, ''),
@@ -50,7 +49,6 @@ env = environ.Env(
 )
 
 USE_RECAPTCHA = env('USE_RECAPTCHA')
-RECAPTCHA_KEY = env('RECAPTCHA_KEY')
 RECAPTCHA_SECRET = env('RECAPTCHA_SECRET')
 
 SSL_PROTECTION = env('SSL_PROTECTION')

--- a/pulseapi/urls.py
+++ b/pulseapi/urls.py
@@ -31,10 +31,16 @@ from pulseapi.utility.urlutils import (
     versioned_api_url,
 )
 
+from .users.utils import LoginRedirectView
+
 urlpatterns = [
     # admin patterns
     url(r'^admin/', admin.site.urls),
 
+    # separate login route so we can gate login behind recaptcha
+    url(r'^login/', LoginRedirectView.as_view(), name='login_redirect'),
+
+    # real login (and other django-allauth) routes
     url(r'^accounts/', include('allauth.urls')),
 
     # 'homepage'

--- a/pulseapi/users/utils.py
+++ b/pulseapi/users/utils.py
@@ -27,7 +27,7 @@ def verify_recaptcha(response_token):
         return False
 
     data = json.loads(response.text)
-    
+
     if data.get('success') is not True:
         return False
 
@@ -51,9 +51,9 @@ class LoginRedirectView(RedirectView):
             response_token = request.GET.get('token', None)
 
             if response_token is None:
-                return HttpResponseForbidden() 
+                return HttpResponseForbidden()
 
             if not verify_recaptcha(response_token):
                 return HttpResponseForbidden()
-        
+
         return super().get(request, *args, **kwargs)

--- a/pulseapi/users/utils.py
+++ b/pulseapi/users/utils.py
@@ -7,6 +7,7 @@ from django.views.generic.base import RedirectView
 from requests import post
 from requests.exceptions import RequestException
 
+# see https://developers.google.com/recaptcha/docs/verify
 RECAPTCHA_VERIFICATION_URL = 'https://www.google.com/recaptcha/api/siteverify'
 
 
@@ -44,7 +45,7 @@ class LoginRedirectView(RedirectView):
     """
     A utility view that redirects requests to the real
     login route, but only if recaptcha validation passes
-    (provided recaptcha is enabled). If recaptcha fails
+    (provided recaptcha is enabled). If recaptcha fails,
     we send an http 403 response.
     """
 

--- a/pulseapi/users/utils.py
+++ b/pulseapi/users/utils.py
@@ -17,23 +17,16 @@ def verify_recaptcha(response_token):
     against what it supposedly generated.
     """
     try:
-        print(f"secret: {settings.RECAPTCHA_SECRET}")
-        
         response = post(RECAPTCHA_VERIFICATION_URL, timeout=5, data={
             'response': response_token,
             'secret': settings.RECAPTCHA_SECRET,
         })
-        
-        print(response)
-
         response.raise_for_status()
 
     except RequestException:
         return False
 
     data = json.loads(response.text)
-    
-    print(data)
     
     if data.get('success') is not True:
         return False
@@ -56,8 +49,6 @@ class LoginRedirectView(RedirectView):
     def get(self, request, *args, **kwargs):
         if settings.USE_RECAPTCHA:
             response_token = request.GET.get('token', None)
-
-            print(f"response_token: {response_token}")
 
             if response_token is None:
                 return HttpResponseForbidden() 

--- a/pulseapi/users/utils.py
+++ b/pulseapi/users/utils.py
@@ -1,0 +1,67 @@
+import json
+
+from django.conf import settings
+from django.http import HttpResponseForbidden
+from django.views.generic.base import RedirectView
+
+from requests import post
+from requests.exceptions import RequestException
+
+RECAPTCHA_VERIFICATION_URL = 'https://www.google.com/recaptcha/api/siteverify'
+
+
+def verify_recaptcha(response_token):
+    """
+    Ask google to verify a client-generated recaptcha token
+    against what it supposedly generated.
+    """
+    try:
+        print(f"secret: {settings.RECAPTCHA_SECRET}")
+        
+        response = post(RECAPTCHA_VERIFICATION_URL, timeout=5, data={
+            'response': response_token,
+            'secret': settings.RECAPTCHA_SECRET,
+        })
+        
+        print(response)
+
+        response.raise_for_status()
+
+    except RequestException:
+        return False
+
+    data = json.loads(response.text)
+    
+    print(data)
+    
+    if data.get('success') is not True:
+        return False
+
+    return True
+
+
+class LoginRedirectView(RedirectView):
+    """
+    A utility view that redirects requests to the real
+    login route, but only if recaptcha validation passes
+    (provided recaptcha is enabled). If recaptcha fails
+    we send an http 403 response.
+    """
+
+    permanent = False
+    query_string = True
+    url = '/accounts/login'
+
+    def get(self, request, *args, **kwargs):
+        if settings.USE_RECAPTCHA:
+            response_token = request.GET.get('token', None)
+
+            print(f"response_token: {response_token}")
+
+            if response_token is None:
+                return HttpResponseForbidden() 
+
+            if not verify_recaptcha(response_token):
+                return HttpResponseForbidden()
+        
+        return super().get(request, *args, **kwargs)


### PR DESCRIPTION
This PR covers the server-side recaptcha work outlined in https://github.com/mozilla/network-pulse-api/issues/762

This gates the login route behind recaptcha validation, if `USE_RECAPTCHA` is enabled.

Requires https://github.com/mozilla/network-pulse/pull/1637 on the client-side.

# Testing

- clone the repo
- have python 3.9 installed - 3.10 is not going to work thanks to ancient dependencies. It is what it is.
- have pip and invoke installed
- run `inv setup`
- this will fail on the db creation part because it has no local postgres available.
- we don't care
- create an `.env` file and use the staging db url as `DATABASE_URL=...` because you do NOT want to set up a postgres 9.6 local instance, or even try to get docker to still do that with properly exposed ports.
- **DO NOT RUN `INV SETUP` OR `INV NEW-DB` FROM THIS POINT ON DURING TESTING**. You'll wipe the staging database. Please don't.
- add `USE_RECAPTCHA=True` to your `.env`
- grab the `localhost (v3)` recaptcha secret from https://www.google.com/recaptcha/admin and add `RECAPTCHA_SECRET=thatvalueyoujustgot` to your `.env`
- run `inv runserver`
- this... should work? If not, let me know, and let's figure out what's still missing.
- continue with the client instructions over on https://github.com/mozilla/network-pulse/pull/1637
