### PR TITLE
Lock down the accounts/login route

### DIFF
--- a/pulseapi/users/utils.py
+++ b/pulseapi/users/utils.py
@@ -1,8 +1,10 @@
 import json
 
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseForbidden
 from django.views.generic.base import RedirectView
+from allauth.account.views import LoginView
 
 from requests import post
 from requests.exceptions import RequestException
@@ -34,6 +36,43 @@ def verify_recaptcha(response_token):
     return True
 
 
+__old_get_context_data = LoginView.get_context_data
+
+
+def augmented_get_context_data(self, **kwargs):
+    """
+    Patch allauth's LoginView.get_context_data class function
+    so that we can check for a recaptcha-related session value
+    if we're using recaptcha. Allauth only has post-processing
+    signals, so we're kind of left with monkey patching as the
+    only way to pre-process the login route.
+    """
+
+    if settings.USE_RECAPTCHA:
+        request = self.request
+        session = request.session
+
+        if 'recaptcha_token' not in session:
+            raise PermissionDenied()
+
+        session_token = session['recaptcha_token']
+        session['recaptcha_token'] = None
+        if session_token is None:
+            raise PermissionDenied()
+
+        client_token = request.GET.get('token', None)
+        if client_token is None:
+            raise PermissionDenied()
+
+        if client_token != session_token:
+            raise PermissionDenied()
+
+    return __old_get_context_data(self, **kwargs)
+
+
+LoginView.get_context_data = augmented_get_context_data
+
+
 class LoginRedirectView(RedirectView):
     """
     A utility view that redirects requests to the real
@@ -48,12 +87,20 @@ class LoginRedirectView(RedirectView):
 
     def get(self, request, *args, **kwargs):
         if settings.USE_RECAPTCHA:
-            response_token = request.GET.get('token', None)
+            client_token = request.GET.get('token', None)
 
-            if response_token is None:
+            if client_token is None:
                 return HttpResponseForbidden()
 
-            if not verify_recaptcha(response_token):
+            if not verify_recaptcha(client_token):
                 return HttpResponseForbidden()
+
+            """
+            note the token in the session, so that the redirect
+            to `accounts/login` works. This allows us to write code
+            that prevents users from directly accessing the allauth
+            login route, thus preventing recaptcha circumvention.
+            """
+            request.session['recaptcha_token'] = client_token
 
         return super().get(request, *args, **kwargs)


### PR DESCRIPTION
This puts a session-based lock in front of the django-allauth `accounts/login` route, so that if recaptcha is enabled, users _have_ to first hit `/login` before they're redirected to `accounts/login`, yielding a 403 if they try to directly access the allauth login route.