### PR TITLE
reduce the autoreload logging, and allow custom runserver

### DIFF
--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -415,7 +415,7 @@ LOGGING = {
         },
         'django.utils.autoreload': {
             'handlers': ['debug'],
-           'level': 'INFO',
+            'level': 'INFO',
         }
     }
 }

--- a/pulseapi/settings.py
+++ b/pulseapi/settings.py
@@ -413,6 +413,10 @@ LOGGING = {
             'handlers': ['debug-error'],
             'level': 'ERROR'
         },
+        'django.utils.autoreload': {
+            'handlers': ['debug'],
+           'level': 'INFO',
+        }
     }
 }
 DJANGO_LOG_LEVEL = env('DJANGO_LOG_LEVEL')

--- a/tasks.py
+++ b/tasks.py
@@ -120,9 +120,9 @@ def manage(ctx, command):
 
 
 @task
-def runserver(ctx):
+def runserver(ctx, arguments):
     """Start a web server"""
-    manage(ctx, "runserver")
+    manage(ctx, f"runserver {arguments}")
 
 
 @task


### PR DESCRIPTION
no associated issue, but this makes it much better to work with the pulse API