### PR TITLE
updated admin so we dont get 500 error when trying to view profiles

### DIFF
--- a/pulseapi/users/admin.py
+++ b/pulseapi/users/admin.py
@@ -66,7 +66,7 @@ class EmailUserAdmin(UserAdmin):
             return instance.profile.user_bio
         except AttributeError:
             return 'Missing profile'
-    
+
     def user_profile(self, instance):
         """
         Link to this user's profile

--- a/pulseapi/users/admin.py
+++ b/pulseapi/users/admin.py
@@ -61,14 +61,12 @@ class EmailUserAdmin(UserAdmin):
         except AttributeError:
             return 'Missing profile'
 
-
     def bio(self, instance):
         try:
             return instance.profile.user_bio
         except AttributeError:
             return 'Missing profile'
-
-            
+    
     def user_profile(self, instance):
         """
         Link to this user's profile

--- a/pulseapi/users/admin.py
+++ b/pulseapi/users/admin.py
@@ -71,11 +71,14 @@ class EmailUserAdmin(UserAdmin):
         """
         Link to this user's profile
         """
-        profile = instance.profile
 
-        html = '<a href="{url}">Click here for this user\'s profile</a>'.format(
-            url=get_admin_url(profile)
-        )
+        try:
+            profile = instance.profile
+            html = '<a href="{url}">Click here for this user\'s profile</a>'.format(
+                url=get_admin_url(profile)
+            )
+        except AttributeError:
+            html = '<p>No profile found for this user.</p>'
 
         return format_html(html)
 

--- a/pulseapi/users/admin.py
+++ b/pulseapi/users/admin.py
@@ -56,11 +56,19 @@ class EmailUserAdmin(UserAdmin):
     entries.short_description = 'Entries posted by this user'
 
     def account_created(self, instance):
-        return instance.profile.created_at
+        try:
+            return instance.profile.created_at
+        except AttributeError:
+            return 'Missing profile'
+
 
     def bio(self, instance):
-        return instance.profile.user_bio
+        try:
+            return instance.profile.user_bio
+        except AttributeError:
+            return 'Missing profile'
 
+            
     def user_profile(self, instance):
         """
         Link to this user's profile


### PR DESCRIPTION
Closes #793 

Fixes bug where the admin will return a 500 error since there are some users without profiles. This implements a try block and if there is no profile will instead return the string 'Missing profile'