### PR TITLE
making posts from "inactive" users only visible to them.

### DIFF
--- a/pulseapi/creators/tests.py
+++ b/pulseapi/creators/tests.py
@@ -50,3 +50,19 @@ class TestEntryCreatorViews(PulseStaffTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(profile.id, response_creator['creator_id'])
+
+    def test_creator_filtering_hiding_inactive_users(self):
+        """Testing that inactive users are not returned in the creator view"""
+        profile = UserProfile.objects.last()
+        # Creating an "inactive" user account to link to the profile,
+        # as we are filtering to show only active profiles in our API views.
+        BasicEmailUserFactory(profile=profile, is_active=False)
+
+        response = self.client.get('{creator_url}?name={search}'.format(
+            creator_url=reverse('creators-list'),
+            search=quote(profile.name)
+        ))
+        search_results = json.loads(str(response.content, 'utf-8'))['results']
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(search_results, [])

--- a/pulseapi/creators/views.py
+++ b/pulseapi/creators/views.py
@@ -68,7 +68,7 @@ class CreatorListView(ListAPIView):
     - ?name= - a partial match filter based on the start of the creator name.
 
     """
-    queryset = UserProfile.objects.all().order_by('id')
+    queryset = UserProfile.objects.filter(related_user__is_active=True).order_by('id')
     pagination_class = CreatorsPagination
     serializer_class = CreatorSerializer
 

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -68,6 +68,12 @@ class EntryQuerySet(models.query.QuerySet):
             'related_entry_creators__profile__related_user',
         )
 
+    def by_approved_account(self):
+        """
+        Return all entries that have been created by pulse users who are set to "Active" by moderator.
+        """
+        return self.filter(published_by__profile__related_user__is_active=True)
+
 
 class Entry(models.Model):
     """

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -68,11 +68,11 @@ class EntryQuerySet(models.query.QuerySet):
             'related_entry_creators__profile__related_user',
         )
 
-    def by_active_account(self):
+    def by_active_user(self):
         """
         Return all entries that have been created by pulse users who are set to "Active" by moderator.
         """
-        return self.filter(published_by__profile__related_user__is_active=True)
+        return self.filter(published_by__is_active=True)
 
 
 class Entry(models.Model):

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -68,7 +68,7 @@ class EntryQuerySet(models.query.QuerySet):
             'related_entry_creators__profile__related_user',
         )
 
-    def by_approved_account(self):
+    def by_active_account(self):
         """
         Return all entries that have been created by pulse users who are set to "Active" by moderator.
         """

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -466,7 +466,7 @@ class EntriesListView(ListCreateAPIView):
                     queryset = Entry.objects.filter(moderation_state=mvalue)
 
         if queryset is False:
-            queryset = Entry.objects.public().with_related().by_approved_account()
+            queryset = Entry.objects.public().with_related().by_active_account()
 
         # If the query was for a set of specific entries,
         # filter the query set further.

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -466,7 +466,7 @@ class EntriesListView(ListCreateAPIView):
                     queryset = Entry.objects.filter(moderation_state=mvalue)
 
         if queryset is False:
-            queryset = Entry.objects.public().with_related().by_active_account()
+            queryset = Entry.objects.public().with_related().by_active_user()
 
         # If the query was for a set of specific entries,
         # filter the query set further.

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -466,7 +466,7 @@ class EntriesListView(ListCreateAPIView):
                     queryset = Entry.objects.filter(moderation_state=mvalue)
 
         if queryset is False:
-            queryset = Entry.objects.public().with_related()
+            queryset = Entry.objects.public().with_related().by_approved_account()
 
         # If the query was for a set of specific entries,
         # filter the query set further.

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -339,6 +339,9 @@ class TestProfileView(PulseMemberTestCase):
         for _ in range(3):
             profile = ExtendedUserProfileFactory(profile_type=profile_type, **profile_params)
             profile.thumbnail = None
+            # Creating an "active" user account to link to the profile,
+            # as we are filtering to show only active profiles in our API views.
+            BasicEmailUserFactory(profile=profile, is_active=True)
             profile.save()
 
         # Expected queryset
@@ -435,6 +438,9 @@ class TestProfileView(PulseMemberTestCase):
                     profile.profile_type = profile_type
                     profile.program_type = program_type
                     profile.program_year = program_year
+                    # Creating an "active" user account to link to the profile,
+                    # as we are filtering to show only active profiles in our API views.
+                    BasicEmailUserFactory(profile=profile, is_active=True)
                     profile.save()
 
         profile_url = reverse('profile_list')

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -339,10 +339,11 @@ class TestProfileView(PulseMemberTestCase):
         for _ in range(3):
             profile = ExtendedUserProfileFactory(profile_type=profile_type, **profile_params)
             profile.thumbnail = None
+            profile.save()
+
             # Creating an "active" user account to link to the profile,
             # as we are filtering to show only active profiles in our API views.
             BasicEmailUserFactory(profile=profile, is_active=True)
-            profile.save()
 
         # Expected queryset
         ordering = query_dict.get('ordering', '-id').split(',')
@@ -438,10 +439,11 @@ class TestProfileView(PulseMemberTestCase):
                     profile.profile_type = profile_type
                     profile.program_type = program_type
                     profile.program_year = program_year
+                    profile.save()
+
                     # Creating an "active" user account to link to the profile,
                     # as we are filtering to show only active profiles in our API views.
                     BasicEmailUserFactory(profile=profile, is_active=True)
-                    profile.save()
 
         profile_url = reverse('profile_list')
 

--- a/pulseapi/profiles/views/profiles.py
+++ b/pulseapi/profiles/views/profiles.py
@@ -242,7 +242,7 @@ class UserProfileListAPIView(ListAPIView):
 
     def get_queryset(self):
         request = self.request
-        queryset = UserProfile.objects.all().prefetch_related('related_user')
+        queryset = UserProfile.objects.filter(related_user__is_active=True).prefetch_related('related_user')
 
         if not request or request.version != settings.API_VERSIONS['version_2']:
             # for all requests that aren't v2, we don't need to prefetch


### PR DESCRIPTION
Closes #791 

This pr was created in preparation for #795.

The desired results are:
- Allow inactive users to be able to create/view/edit their own posts.
- However, do not allow these posts or users to be returned in any search results by different users/endpoints, until the original poster is active themselves.