### PR TITLE
updating profile.is_active flag based on user_account.is_active

### DIFF
--- a/pulseapi/profiles/admin.py
+++ b/pulseapi/profiles/admin.py
@@ -56,6 +56,7 @@ class UserProfileAdmin(admin.ModelAdmin):
 
     list_display = (
         'name',
+        'is_active',
         'profile_type',
         'program_type',
         'program_year',

--- a/pulseapi/profiles/migrations/0025_transfer_user_isactive_to_profile.py
+++ b/pulseapi/profiles/migrations/0025_transfer_user_isactive_to_profile.py
@@ -10,14 +10,11 @@ def match_profile_isactive_to_user_isactive(apps, schema):
 
     for user in network_pulse_users:
 
-        users_profile, created = UserProfile.objects.get_or_create(related_user=user)
+        user_profile, created = UserProfile.objects.get_or_create(related_user=user)
 
-        if user.is_active:
-            users_profile.is_active = True
-        else:
-            users_profile.is_active = False
+        user_profile.is_active = user.is_active
 
-        users_profile.save()
+        user_profile.save()
 
 
 class Migration(migrations.Migration):

--- a/pulseapi/profiles/migrations/0025_transfer_user_isactive_to_profile.py
+++ b/pulseapi/profiles/migrations/0025_transfer_user_isactive_to_profile.py
@@ -24,7 +24,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(
-            match_profile_isactive_to_user_isactive
-        ),
+        migrations.RunPython(code=match_profile_isactive_to_user_isactive, reverse_code=migrations.RunPython.noop)
     ]

--- a/pulseapi/profiles/migrations/0025_transfer_user_isactive_to_profile.py
+++ b/pulseapi/profiles/migrations/0025_transfer_user_isactive_to_profile.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+from django.conf import settings
+
+
+def match_profile_isactive_to_user_isactive(apps, schema):
+    EmailUser = apps.get_model('users', 'EmailUser')
+    UserProfile = apps.get_model('profiles', 'UserProfile')
+
+    network_pulse_users = EmailUser.objects.all()
+
+    for user in network_pulse_users:
+
+        users_profile, created = UserProfile.objects.get_or_create(related_user=user)
+
+        if user.is_active:
+            users_profile.is_active = True
+        else:
+            users_profile.is_active = False
+
+        users_profile.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0024_delete_orphan_profiles'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            match_profile_isactive_to_user_isactive
+        ),
+    ]

--- a/pulseapi/tests.py
+++ b/pulseapi/tests.py
@@ -102,13 +102,17 @@ class JSONDefaultClient(Client):
         )
 
 
-def create_logged_in_user(test, name, email, password="password1234", is_moderator=False):
+def create_logged_in_user(test, name, email, password="password1234", is_moderator=False, is_active=False):
     test.name = name
 
     # create use instance
     User = EmailUser
     user = User.objects.create_user(name=name, email=email, password=password)
     user.save()
+
+    if is_active:
+        user.profile.is_active = True
+        user.profile.save()
 
     # make sure this user is in the staff group, too
     if is_staff_address(email):
@@ -151,14 +155,16 @@ def generate_payload(test, data={}, exclude={}, payload=False):
     return json.dumps(payload)
 
 
-def boostrap(test, name, email, is_moderator=False):
+def boostrap(test, name, email, is_moderator=False, is_active=False):
     setup_groups()
     create_logged_in_user(
         test,
         name=name,
         email=email,
-        is_moderator=is_moderator
+        is_moderator=is_moderator,
+        is_active=is_active
     )
+
     setup_users_with_profiles(test)
     setup_entries(test, creator_users=test.users_with_profiles)
 
@@ -173,7 +179,8 @@ class PulseMemberTestCase(TestCase):
         boostrap(
             self,
             name="plain user",
-            email="test@example.org"
+            email="test@example.org",
+            is_active=True
         )
 
     def generatePostPayload(self, data={}, exclude=[]):
@@ -190,7 +197,8 @@ class PulseStaffTestCase(TestCase):
         boostrap(
             self,
             name="staff user",
-            email="test@mozillafoundation.org"
+            email="test@mozillafoundation.org",
+            is_active=True
         )
 
     def generatePostPayload(self, data={}, exclude=[]):
@@ -206,7 +214,8 @@ class PulseModeratorTestCase(TestCase):
             self,
             name="Moderator user",
             email="moderator@example.org",
-            is_moderator=True
+            is_moderator=True,
+            is_active=True
         )
 
     def generatePostPayload(self, data={}, exclude=[]):

--- a/pulseapi/users/adapter.py
+++ b/pulseapi/users/adapter.py
@@ -111,7 +111,7 @@ class PulseSocialAccountAdapter(DefaultSocialAccountAdapter):
         try:
             UserProfile.objects.get(related_user=user)
         except UserProfile.DoesNotExist:
-            profile = UserProfile.objects.create(is_active=True)
+            profile = UserProfile.objects.create(is_active=False)
             user.profile = profile
             user.save()
 

--- a/pulseapi/users/adapter.py
+++ b/pulseapi/users/adapter.py
@@ -111,6 +111,9 @@ class PulseSocialAccountAdapter(DefaultSocialAccountAdapter):
         try:
             UserProfile.objects.get(related_user=user)
         except UserProfile.DoesNotExist:
+            
+            # Is_active is False by default, so we can hide this 
+            # users profile and entries, until set to active by a moderator.
             profile = UserProfile.objects.create(is_active=False)
             user.profile = profile
             user.save()

--- a/pulseapi/users/adapter.py
+++ b/pulseapi/users/adapter.py
@@ -111,8 +111,7 @@ class PulseSocialAccountAdapter(DefaultSocialAccountAdapter):
         try:
             UserProfile.objects.get(related_user=user)
         except UserProfile.DoesNotExist:
-            
-            # Is_active is False by default, so we can hide this 
+            # Is_active is False by default, so we can hide this
             # users profile and entries, until set to active by a moderator.
             profile = UserProfile.objects.create(is_active=False)
             user.profile = profile

--- a/pulseapi/users/models.py
+++ b/pulseapi/users/models.py
@@ -22,6 +22,8 @@ class EmailUserManager(BaseUserManager):
 
         # Ensure that new users get a user profile associated
         # with them, even though it'll be empty by default.
+        # Is_active is set to False, so we can hide this 
+        # user's profile and entries, until set to active by a moderator.
         profile = UserProfile.objects.create(is_active=False)
         user = self.model(
             email=email,

--- a/pulseapi/users/models.py
+++ b/pulseapi/users/models.py
@@ -22,7 +22,7 @@ class EmailUserManager(BaseUserManager):
 
         # Ensure that new users get a user profile associated
         # with them, even though it'll be empty by default.
-        # Is_active is set to False, so we can hide this 
+        # Is_active is set to False, so we can hide this
         # user's profile and entries, until set to active by a moderator.
         profile = UserProfile.objects.create(is_active=False)
         user = self.model(

--- a/pulseapi/users/models.py
+++ b/pulseapi/users/models.py
@@ -22,7 +22,7 @@ class EmailUserManager(BaseUserManager):
 
         # Ensure that new users get a user profile associated
         # with them, even though it'll be empty by default.
-        profile = UserProfile.objects.create(is_active=True)
+        profile = UserProfile.objects.create(is_active=False)
         user = self.model(
             email=email,
             name=name,

--- a/pulseapi/users/signals.py
+++ b/pulseapi/users/signals.py
@@ -10,4 +10,5 @@ def delete_profile_for_user(sender, **kwargs):
     if kwargs['instance'].profile_id:
         related_profile_id = kwargs['instance'].profile_id
         related_profile = UserProfile.objects.get(id=related_profile_id)
-        related_profile.delete()
+        if related_profile:
+            related_profile.delete()

--- a/pulseapi/users/signals.py
+++ b/pulseapi/users/signals.py
@@ -1,21 +1,12 @@
-from django.conf import settings
 from django.dispatch import receiver
-from django.db.models.signals import pre_save, post_delete
+from django.db.models.signals import post_delete
 
 from .models import EmailUser
 from pulseapi.profiles.models import UserProfile
 
-
-@receiver(pre_save, sender=EmailUser)
-def default_to_non_active(sender, instance, **kwargs):
-    if settings.TESTING:
-        return
-    if instance._state.adding is True:
-        instance.is_active = False
-
-
 @receiver(post_delete, sender=EmailUser)
 def delete_profile_for_user(sender, **kwargs):
-    related_profile_id = kwargs['instance'].profile_id
-    related_profile = UserProfile.objects.get(id=related_profile_id)
-    related_profile.delete()
+    if kwargs['instance'].profile_id:
+        related_profile_id = kwargs['instance'].profile_id
+        related_profile = UserProfile.objects.get(id=related_profile_id)
+        related_profile.delete()

--- a/pulseapi/users/signals.py
+++ b/pulseapi/users/signals.py
@@ -4,6 +4,7 @@ from django.db.models.signals import post_delete
 from .models import EmailUser
 from pulseapi.profiles.models import UserProfile
 
+
 @receiver(post_delete, sender=EmailUser)
 def delete_profile_for_user(sender, **kwargs):
     if kwargs['instance'].profile_id:


### PR DESCRIPTION
[**NOTE:**] We should coordinate when this can merge into the codebase, as this will allow "spam accounts" to sign up and to create posts without moderation 


Closes: #798 
Related PRs: #788, #789

In an effort to prepare for the tickets that will implement the new sign up flow:

1. New user logs in
2. They can access their profile and make entries
3. These posts and profile will be omitted from frontend until a admin updates their profile to "is_active".


We are now updating the app from "setting `user_account.is_active` to `False` on initial login" to "setting `profile.is_active` to `False` on initial login". That way the user can view/edit their profile, and we can then filter posts based on `profile.is_active`.


