### PR TITLE
updated API endpoints to omit inactive profiles and their entries

### DIFF
--- a/pulseapi/creators/tests.py
+++ b/pulseapi/creators/tests.py
@@ -18,7 +18,7 @@ class TestEntryCreatorViews(PulseStaffTestCase):
         page = CreatorsPagination()
         expected_data = CreatorSerializer(
             page.paginate_queryset(
-                UserProfile.objects.filter(is_active=True).order_by('id'), # Filtering for active profiles only
+                UserProfile.objects.active().order_by('id'),  # Filtering for active profiles only
                 request=Request(request=HttpRequest())  # mock request to satisfy the required arguments
             ),
             many=True

--- a/pulseapi/creators/tests.py
+++ b/pulseapi/creators/tests.py
@@ -18,7 +18,7 @@ class TestEntryCreatorViews(PulseStaffTestCase):
         page = CreatorsPagination()
         expected_data = CreatorSerializer(
             page.paginate_queryset(
-                UserProfile.objects.filter(is_active=True).order_by('id'), # Filtering for only active profiles
+                UserProfile.objects.filter(is_active=True).order_by('id'), # Filtering for active profiles only
                 request=Request(request=HttpRequest())  # mock request to satisfy the required arguments
             ),
             many=True

--- a/pulseapi/creators/views.py
+++ b/pulseapi/creators/views.py
@@ -68,7 +68,7 @@ class CreatorListView(ListAPIView):
     - ?name= - a partial match filter based on the start of the creator name.
 
     """
-    queryset = UserProfile.objects.all().order_by('id')
+    queryset = UserProfile.objects.filter(is_active=True).order_by('id')
     pagination_class = CreatorsPagination
     serializer_class = CreatorSerializer
 

--- a/pulseapi/creators/views.py
+++ b/pulseapi/creators/views.py
@@ -68,7 +68,7 @@ class CreatorListView(ListAPIView):
     - ?name= - a partial match filter based on the start of the creator name.
 
     """
-    queryset = UserProfile.objects.filter(is_active=True).order_by('id')
+    queryset = UserProfile.objects.active().order_by('id')
     pagination_class = CreatorsPagination
     serializer_class = CreatorSerializer
 

--- a/pulseapi/entries/models.py
+++ b/pulseapi/entries/models.py
@@ -68,6 +68,12 @@ class EntryQuerySet(models.query.QuerySet):
             'related_entry_creators__profile__related_user',
         )
 
+    def by_active_profile(self):
+        """
+        Return all entries that have been created by pulse users who's profiles are set to "Active" by moderator.
+        """
+        return self.filter(published_by__profile__is_active=True)
+
 
 class Entry(models.Model):
     """

--- a/pulseapi/entries/tests/test_member_views.py
+++ b/pulseapi/entries/tests/test_member_views.py
@@ -130,12 +130,6 @@ class TestEntryAPIJSONView(PulseMemberTestCase):
         dual_entry.tags.add(libraries)
         dual_entry.save()
 
-        inactive_profile_user = BasicEmailUserFactory.create(active=False)
-        inactive_profile_entry = Entry.objects.create(
-            title='inactive_profile_entry', entry_type='news', published_by=inactive_profile_user)
-        inactive_profile_entry.set_moderation_state('Approved')
-        inactive_profile_entry.save()
-
     def test_single_tag_search(self):
         response = self.client.get('/api/pulse/entries/?search=curricculum&format=json')
         self.assertEqual(response.status_code, 200)
@@ -157,8 +151,26 @@ class TestEntryAPIJSONView(PulseMemberTestCase):
         self.assertEqual(count, 1)
 
     def test_inactive_profile_entry_is_hidden(self):
-        response = self.client.get('/api/pulse/entries/?search=inactive_profile_entry&format=json')
+        """
+        Creating two entries of the same name, to test that the
+        entry created by an inactive profile will be hidden from results.
+        """
+        entry_name = 'test_entry'
+
+        test_entry = Entry.objects.create(title=entry_name, entry_type='news', published_by=self.user)
+        test_entry.set_moderation_state('Approved')
+        test_entry.save()
+
+        inactive_profile_user = BasicEmailUserFactory.create(active=False)
+        inactive_profile_entry = Entry.objects.create(
+            title=entry_name, entry_type='news', published_by=inactive_profile_user)
+        inactive_profile_entry.set_moderation_state('Approved')
+        inactive_profile_entry.save()
+
+        response = self.client.get(f'/api/pulse/entries/?search={test_entry}&format=json')
         self.assertEqual(response.status_code, 200)
         response_data = json.loads(str(response.content, 'utf-8'))
         count = response_data['count']
-        self.assertEqual(count, 0)
+        returned_entry = response_data['results'][0]
+        self.assertEqual(count, 1)
+        self.assertNotEqual(inactive_profile_entry.id, returned_entry['id'])

--- a/pulseapi/entries/views.py
+++ b/pulseapi/entries/views.py
@@ -466,7 +466,7 @@ class EntriesListView(ListCreateAPIView):
                     queryset = Entry.objects.filter(moderation_state=mvalue)
 
         if queryset is False:
-            queryset = Entry.objects.public().with_related()
+            queryset = Entry.objects.public().with_related().by_active_profile()
 
         # If the query was for a set of specific entries,
         # filter the query set further.

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -521,8 +521,11 @@ class TestProfileView(PulseMemberTestCase):
         response = self.client.get(url)
         entriesjson = json.loads(str(response.content, 'utf-8'))
         num_of_inactive_profiles = sum(profile['is_active'] is False for profile in entriesjson)
+        list_of_returned_profile_ids = [profile['profile_id'] for profile in entriesjson]
 
         self.assertEqual(num_of_inactive_profiles, 0)
+        self.assertIn(active_profile.id, list_of_returned_profile_ids)
+        self.assertNotIn(inactive_profile.id, list_of_returned_profile_ids)
 
     def test_profile_view_is_inactive_filter(self):
         """
@@ -540,5 +543,8 @@ class TestProfileView(PulseMemberTestCase):
         response = self.client.get(url)
         entriesjson = json.loads(str(response.content, 'utf-8'))
         num_of_active_profiles = sum(profile['is_active'] is True for profile in entriesjson)
+        list_of_returned_profile_ids = [profile['profile_id'] for profile in entriesjson]
 
         self.assertEqual(num_of_active_profiles, 0)
+        self.assertIn(inactive_profile.id, list_of_returned_profile_ids)
+        self.assertNotIn(active_profile.id, list_of_returned_profile_ids)

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -479,8 +479,6 @@ class TestProfileView(PulseMemberTestCase):
         self.run_test_profile_list(
             api_version=settings.API_VERSIONS['version_2'],
             profile_serializer_class=UserProfilePublicSerializer,
-            profile_params={'is_active': True},
-            query_dict={'is_active': True},
         )
 
     def test_profile_list_search_v3(self):

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -511,6 +511,8 @@ class TestProfileView(PulseMemberTestCase):
         request to the profile endpoint with the '?is_active' filter set to
         'True', then checking if any returned profiles are set to 'False'.
         """
+        active_profile = BasicUserProfileFactory.create(is_active=True)
+        active_profile.save()
         inactive_profile = BasicUserProfileFactory.create(is_active=False)
         inactive_profile.save()
 
@@ -521,3 +523,22 @@ class TestProfileView(PulseMemberTestCase):
         num_of_inactive_profiles = sum(profile['is_active'] is False for profile in entriesjson)
 
         self.assertEqual(num_of_inactive_profiles, 0)
+
+    def test_profile_view_is_inactive_filter(self):
+        """
+        Similar to 'test_profile_view_is_active_filter',
+        this time setting the filter to FALSE. The API should then return a
+        list only inactive profiles. Which we double check using 'num_of_active_profiles'.
+        """
+        active_profile = BasicUserProfileFactory.create(is_active=True)
+        active_profile.save()
+        inactive_profile = BasicUserProfileFactory.create(is_active=False)
+        inactive_profile.save()
+
+        profile_url = reverse('profile_list')
+        url = ('{url}?is_active=False').format(url=profile_url)
+        response = self.client.get(url)
+        entriesjson = json.loads(str(response.content, 'utf-8'))
+        num_of_active_profiles = sum(profile['is_active'] is True for profile in entriesjson)
+
+        self.assertEqual(num_of_active_profiles, 0)

--- a/pulseapi/profiles/test_views.py
+++ b/pulseapi/profiles/test_views.py
@@ -432,6 +432,7 @@ class TestProfileView(PulseMemberTestCase):
                     (program_year, _) = ProgramYear.objects.get_or_create(value=v3)
                     profile = UserProfile.objects.create()
                     profile.enable_extended_information = True
+                    profile.is_active = True
                     profile.profile_type = profile_type
                     profile.program_type = program_type
                     profile.program_year = program_year

--- a/pulseapi/profiles/views/profiles.py
+++ b/pulseapi/profiles/views/profiles.py
@@ -242,7 +242,14 @@ class UserProfileListAPIView(ListAPIView):
 
     def get_queryset(self):
         request = self.request
-        queryset = UserProfile.objects.all().prefetch_related('related_user')
+        queries = self.request.query_params
+        # If we are doing a specific search for is_active, return a filtered list for either
+        # active or inactive profiles. If we are filtering based on anything else, filter out
+        # inactive profiles by default.
+        if 'is_active' in queries:
+            queryset = UserProfile.objects.all().prefetch_related('related_user')
+        else:
+            queryset = UserProfile.objects.filter(is_active=True).prefetch_related('related_user')
 
         if not request or request.version != settings.API_VERSIONS['version_2']:
             # for all requests that aren't v2, we don't need to prefetch

--- a/pulseapi/profiles/views/profiles.py
+++ b/pulseapi/profiles/views/profiles.py
@@ -249,7 +249,7 @@ class UserProfileListAPIView(ListAPIView):
         if 'is_active' in queries:
             queryset = UserProfile.objects.all().prefetch_related('related_user')
         else:
-            queryset = UserProfile.objects.filter(is_active=True).prefetch_related('related_user')
+            queryset = UserProfile.objects.active().prefetch_related('related_user')
 
         if not request or request.version != settings.API_VERSIONS['version_2']:
             # for all requests that aren't v2, we don't need to prefetch


### PR DESCRIPTION
Closes #791 

This PR introduces the following changes to these endpoints:

/creators/:
--
 - Now using the `UserProfile` models [.active()](https://github.com/mozilla/network-pulse-api/blob/83b134e21526d0695106a49accdcef4b41384d01/pulseapi/profiles/models/profiles.py#L29) filter, to return only profiles with `'is_active'` set to `True` in the queryset.
 - Added a new test in [creators/test.py](https://github.com/mozilla/network-pulse-api/blob/bb94b937eab123c057d129ce137ec1eeec36a6d5/pulseapi/creators/tests.py#L54) to verify that the filtering of active profiles works correctly.

/profiles/:
---
- Updated the queryset in [/views/profiles.py](https://github.com/mozilla/network-pulse-api/blob/bb94b937eab123c057d129ce137ec1eeec36a6d5/pulseapi/profiles/views/profiles.py#L249) to include an `if` statement that checks whether or not someone is using the "`?is_active`" search param. This is so we retain functionality of this filter, and we can filter for "inactive" profiles through the API if needed. However, all other filters will default to  filtering out inactive accounts like requested.
- Updated [test_profile_list_filtering](https://github.com/mozilla/network-pulse-api/blob/bb94b937eab123c057d129ce137ec1eeec36a6d5/pulseapi/profiles/test_views.py#L435) to set the test profiles `is_active` flag to `True`, as without this, they would be set to inactive and the view would return an empty queryset.

/entries/:
---
- Created a new filter for the entry queryset, called [by_active_profile()](https://github.com/mozilla/network-pulse-api/blob/bb94b937eab123c057d129ce137ec1eeec36a6d5/pulseapi/entries/models.py#L71)
- Updated the public [EntriesList queryset](https://github.com/mozilla/network-pulse-api/blob/bb94b937eab123c057d129ce137ec1eeec36a6d5/pulseapi/entries/views.py#L469) to return only entries by active profiles.
- Added a new test in [test_member_views.py](https://github.com/mozilla/network-pulse-api/blob/bb94b937eab123c057d129ce137ec1eeec36a6d5/pulseapi/entries/tests/test_member_views.py#L159) to verify that entries created by inactive users are hidden from the public view.
