### PR TITLE
Move build dependencies into requirements.txt for Heroku compatibility

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,2 +1,0 @@
-setuptools==65.5.1
-wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,11 @@
 #    pip-compile
 #
 
-# Required on Heroku to prevent build failures with legacy packages like django-allauth
-# Ensures build dependencies (e.g. setuptools, wheel) are installed before other packages
--r build-requirements.txt
+# The two lines below are needed for Heroku compatibility.
+# `setuptools==65.5.1` ensures compatibility with legacy packages like django-allauth,
+# and `wheel` is needed for building packages from source.
+setuptools==65.5.1
+wheel
 
 boto3==1.16.26
     # via -r requirements.in
@@ -161,6 +163,3 @@ urllib3==1.25.9
     #   requests
 whitenoise==5.2.0
     # via -r requirements.in
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
This PR resolves [build issues on Heroku](https://dashboard.heroku.com/apps/network-pulse-api-staging/activity/builds/3caac6e0-fab2-4338-9dbf-021e750bc865) by moving the `setuptools` and `wheel` dependencies from `build-requirements.txt` into the main `requirements.txt` file.

Heroku uses `requirements.txt` as the default install target during the slug build process. Having `setuptools` and `wheel` there ensures that packages like `django-allauth`, which rely on older setup.py behavior, install correctly without metadata generation errors.