### PR TITLE
Fix Heroku deployment by pre-installing compatible setuptools version

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script is only used by Heroku during dyno startup.
+# It ensures setuptools is downgraded early to avoid install issues with legacy packages like django-allauth.
+# Local environments ignore this file.
+
+pip install "setuptools==65.5.1" --no-cache-dir --upgrade


### PR DESCRIPTION
To address the Heroku deployment issue seen in https://dashboard.heroku.com/apps/network-pulse-api-staging/activity/builds/55e531d0-2910-41b3-be70-1c0c23b6093e


---

Heroku installs a recent version of setuptools (70.x) before running `pip install -r requirements.txt`, which causes an import error in `django-allauth==0.48.0`. This is because newer versions of setuptools have removed `convert_path`, which allauth's setup.py still relies on.

Although `setuptools==65.5.1` is already pinned in our requirements, Heroku doesn't respect that pin early enough during the build process.

To fix this, this PR introduces a `.profile` script that Heroku runs at dyno startup. It explicitly installs `setuptools==65.5.1` before any other dependencies are installed.

This change has no effect on local environments. `.profile` is only executed by Heroku.
